### PR TITLE
Use setTimeout

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 [*]
 # For [accessibility reasons](https://alexandersandberg.com/tabs-for-accessibility/)
-indent_style = space
+indent_style = tab
 indent_size = 4
 end_of_line = lf
 charset = utf-8

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayProxyCallback, APIGatewayProxyResult } from 'aws-lambda';
 import * as AWS from 'aws-sdk';
 import * as SSM from 'aws-sdk/clients/ssm';
 import { Pool } from 'pg';
@@ -81,7 +81,7 @@ export const run = async (
 export const handler = (
 	event: APIGatewayEvent,
 	context: unknown,
-	callback: (err: Error | null, result?: APIGatewayProxyResult) => void,
+	callback: APIGatewayProxyCallback,
 ): void => {
 	// setTimeout is necessary because of a bug in the node lambda runtime which can break requests to ssm
 	setTimeout(() => {

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -27,7 +27,7 @@ const identityAccessTokenPromise: Promise<string> = getParamFromSSM(
 	`/support-reminders/idapi/${ssmStage}/accessToken`,
 );
 
-export const handler = async (
+export const run = async (
 	event: APIGatewayEvent,
 ): Promise<APIGatewayProxyResult> => {
 	console.log('received event: ', event);
@@ -76,4 +76,17 @@ export const handler = async (
 			body: statusCode.toString(),
 		};
 	}
+};
+
+export const handler = (
+	event: APIGatewayEvent,
+	context: unknown,
+	callback: (err: Error | null, result?: APIGatewayProxyResult) => void,
+): void => {
+	// setTimeout is necessary because of a bug in the node lambda runtime which can break requests to ssm
+	setTimeout(() => {
+		run(event)
+			.then((result) => callback(null, result))
+			.catch((err) => callback(err));
+	});
 };

--- a/src/create-reminder-signup/lambda/local.ts
+++ b/src/create-reminder-signup/lambda/local.ts
@@ -1,11 +1,11 @@
 import * as AWS from 'aws-sdk';
-import { handler } from './lambda';
+import { run } from './lambda';
 
 const config = new AWS.Config();
 const credentials = new AWS.SharedIniFileCredentials({ profile: 'membership' });
 config.update({ region: 'eu-west-1', credentials });
 
-function run() {
+function runLocal() {
 	console.log(__dirname);
 	process.env.Stage = 'DEV';
 
@@ -19,7 +19,7 @@ function run() {
 		}),
 	};
 
-	handler(event)
+	run(event)
 		.then((result) => {
 			console.log('============================');
 			console.log('Result: ', result);
@@ -30,4 +30,4 @@ function run() {
 		});
 }
 
-run();
+runLocal();

--- a/src/create-reminder-signup/lambda/models.ts
+++ b/src/create-reminder-signup/lambda/models.ts
@@ -32,8 +32,8 @@ function isValidEmail(email: string): boolean {
 type ReminderPeriod = string;
 
 function isValidReminderPeriod(reminderPeriod: string): boolean {
-    const date = Date.parse(reminderPeriod);
-    return !isNaN(date);
+	const date = Date.parse(reminderPeriod);
+	return !isNaN(date);
 }
 
 export interface OneOffSignupRequest {


### PR DESCRIPTION
This is to avoid a bug in the aws lambda node runtime, based on their advice.
We've had issues in the past where making requests to ssm in the global scope sometimes fails.