### PR TITLE
Run tsc in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "clean": "rm -rf target",
     "lint": "eslint ./src --ext .js,.ts",
-    "build": "babel src --out-dir target --extensions \".ts\"",
+    "build": "tsc && babel src --out-dir target --extensions \".ts\"",
     "create-reminder-signup": "yarn build && node target/create-reminder-signup/lambda/local.js",
     "package": "ARTEFACT_PATH=$PWD/target VERBOSE=true riffraff-artefact"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
-  "compilerOptions": {
-    "target": "ESNEXT",
-    "module": "commonjs",
-    "outDir": "./target",
-    "sourceMap": true,
-    "strict": true,
-    "allowJs": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "node"
-  },
-  "include": [
-    "./src/**/*.ts",
-    "./**/gen-nodejs/*.js"
-  ]
+	"compilerOptions": {
+		"noEmit": true,
+		"target": "ESNEXT",
+		"module": "commonjs",
+		"sourceMap": true,
+		"strict": true,
+		"allowJs": true,
+		"resolveJsonModule": true,
+		"moduleResolution": "node"
+	},
+	"include": [
+		"./src/**/*.ts",
+		"./**/gen-nodejs/*.js"
+	]
 }


### PR DESCRIPTION
We now use babel to build the js because we use it for generating type validators. But for completeness let's also run tsc first (without outputting any files)