### PR TITLE
Add recurring signups

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -84,11 +84,16 @@ Resources:
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/support-reminders/db-config/${Stage}
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/support-reminders/idapi/${Stage}/*
       Events:
-        HttpPost:
-          Type: Api
-          Properties:
-            Path: '/remind-me'
-            Method: post
+        CreateOneOff:
+            Type: Api
+            Properties:
+                Path: '/create/one-off'
+                Method: post
+        CreateRecurring:
+            Type: Api
+            Properties:
+                Path: '/create/recurring'
+                Method: post
 
   NextRemindersLambda:
     Type: AWS::Serverless::Function

--- a/src/create-reminder-signup/lambda/dummy-input.json
+++ b/src/create-reminder-signup/lambda/dummy-input.json
@@ -1,3 +1,0 @@
-{
-    "reminderSource": "EPIC"
-}

--- a/src/create-reminder-signup/lambda/local.ts
+++ b/src/create-reminder-signup/lambda/local.ts
@@ -10,9 +10,11 @@ function runLocal() {
 	process.env.Stage = 'DEV';
 
 	const event = {
+		path: '/create/one-off',
 		body: JSON.stringify({
 			email: 'test-reminders10@theguardian.com',
 			reminderPeriod: '2021-01-01',
+			reminderFrequencyMonths: 3,
 			reminderPlatform: 'WEB',
 			reminderComponent: 'EPIC',
 			reminderStage: 'PRE',

--- a/src/create-reminder-signup/lambda/one-off.example.json
+++ b/src/create-reminder-signup/lambda/one-off.example.json
@@ -1,0 +1,8 @@
+{
+  "email": "test-reminders10@theguardian.com",
+  "reminderPeriod": "2021-01-01",
+  "reminderPlatform": "WEB",
+  "reminderComponent": "EPIC",
+  "reminderStage": "PRE",
+  "reminderOption": "us-eoy-2020-both"
+}

--- a/src/create-reminder-signup/lambda/recurring.example.json
+++ b/src/create-reminder-signup/lambda/recurring.example.json
@@ -1,0 +1,8 @@
+{
+  "email": "test-reminders10@theguardian.com",
+  "reminderFrequencyMonths": 6,
+  "reminderPlatform": "WEB",
+  "reminderComponent": "THANKYOU",
+  "reminderStage": "POST",
+  "reminderOption": "6-months"
+}

--- a/src/create-reminder-signup/lib/db.ts
+++ b/src/create-reminder-signup/lib/db.ts
@@ -1,6 +1,6 @@
 import { Pool, QueryConfig, QueryResult } from 'pg';
 import { runWithLogging } from '../../lib/db';
-import { OneOffSignup } from '../lambda/models';
+import { OneOffSignup, RecurringSignup } from '../lambda/models';
 
 export function writeOneOffSignup(
 	signup: OneOffSignup,
@@ -20,8 +20,8 @@ export function writeOneOffSignup(
                 $1, $2, $3, $4, $5, $6, $7
             )
             ON CONFLICT ON CONSTRAINT one_off_reminder_signups_pkey
-            DO 
-                UPDATE SET 
+            DO
+                UPDATE SET
                     reminder_created_at = $3,
                     reminder_platform = $4,
                     reminder_component = $5,
@@ -32,6 +32,48 @@ export function writeOneOffSignup(
 		values: [
 			signup.identity_id,
 			signup.reminder_period,
+			signup.reminder_created_at,
+			signup.reminder_platform,
+			signup.reminder_component,
+			signup.reminder_stage,
+			signup.reminder_option,
+		],
+	};
+
+	return runWithLogging(query, pool);
+}
+
+export function writeRecurringSignup(
+	signup: RecurringSignup,
+	pool: Pool,
+): Promise<QueryResult> {
+	const query: QueryConfig = {
+		text: `
+            INSERT INTO recurring_reminder_signups(
+                identity_id,
+                reminder_frequency_months,
+                reminder_created_at,
+                reminder_platform,
+                reminder_component,
+                reminder_stage,
+                reminder_option
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7
+            )
+            ON CONFLICT ON CONSTRAINT recurring_reminder_signups_pkey
+            DO
+                UPDATE SET
+					reminder_frequency_months = $2,
+                    reminder_created_at = $3,
+                    reminder_platform = $4,
+                    reminder_component = $5,
+                    reminder_stage = $6,
+                    reminder_option = $7
+            RETURNING *;
+        `,
+		values: [
+			signup.identity_id,
+			signup.reminder_frequency_months,
 			signup.reminder_created_at,
 			signup.reminder_platform,
 			signup.reminder_component,


### PR DESCRIPTION
## What does this change?
Add recurring reminder signups. This uses the existing singups lambda, which now has two endpoints associated with it: `POST /create/one-off` and `POST /create/recurring` (I suppose if we want to be RESTful, then these should just be e.g `POST /one-offs` and `POST /recurring`).

Testing in `CODE` with e.g 
```bash
http post https://reminders-code.support.guardianapis.com/create/recurring \
    email=tom.pretty@guardian.co.uk \
    reminderFrequencyMonths:=6  \
    reminderPlatform=WEB \
    reminderComponent=EPIC \
    reminderStage=PRE
```

Returns

<img width="576" alt="Screenshot 2021-02-08 at 08 55 56" src="https://user-images.githubusercontent.com/17720442/107197204-808eb800-69eb-11eb-9469-51561df81098.png">

Which can then be seen in the `CODE` database

<img width="1339" alt="Screenshot 2021-02-08 at 08 58 57" src="https://user-images.githubusercontent.com/17720442/107197626-06126800-69ec-11eb-98ed-84e13dc9819d.png">