### PR TITLE
Save country code to signups table

### DIFF
--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -79,17 +79,21 @@ export const runRecurring = async (
 	return createSignup(signupRequest, recurringSignupValidator, persist);
 };
 
+type Validator<T> = (
+	signupRequest: unknown,
+	validationErrors: ValidationErrors,
+) => signupRequest is T;
+
+type Persist<T> = (
+	signupRequest: T,
+	identityId: string,
+	pool: Pool,
+) => Promise<QueryResult>;
+
 const createSignup = async <T extends BaseSignupRequest>(
 	signupRequest: unknown,
-	validator: (
-		signupRequest: unknown,
-		validationErrors: ValidationErrors,
-	) => signupRequest is T,
-	persist: (
-		signupRequest: T,
-		identityId: string,
-		pool: Pool,
-	) => Promise<QueryResult>,
+	validator: Validator<T>,
+	persist: Persist<T>,
 ) => {
 	const validationErrors: ValidationErrors = [];
 	if (!validator(signupRequest, validationErrors)) {

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -37,7 +37,8 @@ export const run = async (
 ): Promise<APIGatewayProxyResult> => {
 	console.log('received event: ', event);
 
-	const signupRequest: unknown = JSON.parse(event.body);
+	const country = event.headers['X-GU-GeoIP-Country-Code'];
+	const signupRequest: unknown = { ...JSON.parse(event.body), country };
 
 	if (event.path === '/create/one-off') {
 		return runOneOff(signupRequest);

--- a/src/create-reminder-signup/lambda/local.ts
+++ b/src/create-reminder-signup/lambda/local.ts
@@ -11,6 +11,9 @@ function runLocal() {
 
 	const event = {
 		path: '/create/one-off',
+		headers: {
+			'X-GU-GeoIP-Country-Code': 'GB',
+		},
 		body: JSON.stringify({
 			email: 'test-reminders10@theguardian.com',
 			reminderPeriod: '2021-01-01',

--- a/src/create-reminder-signup/lambda/models.ts
+++ b/src/create-reminder-signup/lambda/models.ts
@@ -7,6 +7,7 @@ import {
 // Database model
 export interface BaseSignup {
 	identity_id: string;
+	country?: string;
 	reminder_created_at: string;
 	reminder_platform: string;
 	reminder_component: string;
@@ -43,6 +44,7 @@ function isValidReminderPeriod(reminderPeriod: string): boolean {
 
 export interface BaseSignupRequest {
 	email: Email;
+	country?: string;
 	reminderPlatform: ReminderPlatform;
 	reminderComponent: ReminderComponent;
 	reminderStage: ReminderStage;
@@ -58,6 +60,7 @@ export interface RecurringSignupRequest extends BaseSignupRequest {
 }
 
 export interface APIGatewayEvent {
+	headers: Record<string, string | undefined>;
 	path: string;
 	body: string;
 }
@@ -101,6 +104,7 @@ export const oneOffSignupFromRequest = (
 	request: OneOffSignupRequest,
 ): OneOffSignup => ({
 	identity_id: identityId,
+	country: request.country,
 	reminder_period: toDate(request.reminderPeriod),
 	reminder_created_at: new Date().toISOString(),
 	reminder_platform: request.reminderPlatform,
@@ -114,6 +118,7 @@ export const recurringSignupFromRequest = (
 	request: RecurringSignupRequest,
 ): RecurringSignup => ({
 	identity_id: identityId,
+	country: request.country,
 	reminder_frequency_months: request.reminderFrequencyMonths,
 	reminder_created_at: new Date().toISOString(),
 	reminder_platform: request.reminderPlatform,

--- a/src/create-reminder-signup/lib/db.ts
+++ b/src/create-reminder-signup/lib/db.ts
@@ -10,6 +10,7 @@ export function writeOneOffSignup(
 		text: `
             INSERT INTO one_off_reminder_signups(
                 identity_id,
+				country,
                 reminder_period,
                 reminder_created_at,
                 reminder_platform,
@@ -17,20 +18,22 @@ export function writeOneOffSignup(
                 reminder_stage,
                 reminder_option
             ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7
+                $1, $2, $3, $4, $5, $6, $7, $8
             )
             ON CONFLICT ON CONSTRAINT one_off_reminder_signups_pkey
             DO
                 UPDATE SET
-                    reminder_created_at = $3,
-                    reminder_platform = $4,
-                    reminder_component = $5,
-                    reminder_stage = $6,
-                    reminder_option = $7
+                    country = $2,
+                    reminder_created_at = $4,
+                    reminder_platform = $5,
+                    reminder_component = $6,
+                    reminder_stage = $7,
+                    reminder_option = $8
             RETURNING *;
         `,
 		values: [
 			signup.identity_id,
+			signup.country,
 			signup.reminder_period,
 			signup.reminder_created_at,
 			signup.reminder_platform,
@@ -51,6 +54,7 @@ export function writeRecurringSignup(
 		text: `
             INSERT INTO recurring_reminder_signups(
                 identity_id,
+				country,
                 reminder_frequency_months,
                 reminder_created_at,
                 reminder_platform,
@@ -58,21 +62,23 @@ export function writeRecurringSignup(
                 reminder_stage,
                 reminder_option
             ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7
+                $1, $2, $3, $4, $5, $6, $7, $8
             )
             ON CONFLICT ON CONSTRAINT recurring_reminder_signups_pkey
             DO
                 UPDATE SET
-					reminder_frequency_months = $2,
-                    reminder_created_at = $3,
-                    reminder_platform = $4,
-                    reminder_component = $5,
-                    reminder_stage = $6,
-                    reminder_option = $7
+					country = $2,
+					reminder_frequency_months = $3,
+                    reminder_created_at = $4,
+                    reminder_platform = $5,
+                    reminder_component = $6,
+                    reminder_stage = $7,
+                    reminder_option = $8
             RETURNING *;
         `,
 		values: [
 			signup.identity_id,
+			signup.country,
 			signup.reminder_frequency_months,
 			signup.reminder_created_at,
 			signup.reminder_platform,


### PR DESCRIPTION
## What does this change?
We now get the country code from a header set by fastly (provided the the api is accessed via `support.theguardian.com/reminders/*`) which is then saved to the db along with the other signup data. This column was already being exported by the signups-export lambda, so no change was needed there.

Additionally, factored out a couple of types for the `createSignup` function to help with readability. 

You can test it out in `CODE` using httpie with e.g:

```sh
http post https://support.code.dev-theguardian.com/reminders/create/recurring \
    email=tom.pretty@guardian.co.uk \
    reminderFrequencyMonths:=6  \
    reminderPlatform=WEB \
    reminderComponent=BANNER \
    reminderStage=POST
```