### PR TITLE
Export csvs even if there are no rows

### DIFF
--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -9,13 +9,9 @@ export function uploadAsCsvToS3(
 	bucket: string,
 	key: string,
 ): Promise<number> {
-	if (result.rowCount == 0) {
-		return Promise.resolve(0);
-	}
-
-	const header = Object.keys(result.rows[0]).map((key) => ({
-		id: key,
-		title: key,
+	const header = result.fields.map((field) => ({
+		id: field.name,
+		title: field.name,
 	}));
 
 	const csvWriter = createObjectCsvStringifier({


### PR DESCRIPTION
## What does this change?
Make lambda upload csvs to s3 even if there are no rows. In this case it just writes up a csv with a header row