### PR TITLE
return identity response status

### DIFF
--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -140,11 +140,10 @@ const createSignup = async <T extends BaseSignupRequest>(
 			body: 'OK',
 		};
 	} else {
-		const statusCode = identityResult.status === 404 ? 400 : 500;
 		return {
 			headers,
-			statusCode,
-			body: statusCode.toString(),
+			statusCode: identityResult.status,
+			body: identityResult.status.toString(),
 		};
 	}
 };


### PR DESCRIPTION
currently it's returning 500s for bad requests, e.g. email address too long.