### PR TITLE
Increase reminder exports lambda timeout

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -230,7 +230,7 @@ Resources:
       Runtime: nodejs10.x
       Handler: signup-exports/lambda/lambda.handler
       MemorySize: 128
-      Timeout: 30
+      Timeout: 900
       Environment:
         Variables:
           Stage: !Ref Stage


### PR DESCRIPTION
we need a higher timeout for processing historical data. 900 is the max allowed