### PR TITLE
Script to recover cancellations

### DIFF
--- a/scripts/recover-cancellations/README.md
+++ b/scripts/recover-cancellations/README.md
@@ -1,0 +1,20 @@
+#### 1. Download logs from cloudwatch
+
+E.g.
+
+`export AWS_DEFAULT_REGION=eu-west-1 && awslogs get /aws/lambda/support-reminders-cancel-reminders-PROD --start='2021-06-15 16:00' --end='2021-06-16 09:00' --filter-pattern="invalid input syntax for type uuid" --profile membership > filtered-dump.log`
+
+#### 2. Extract the base64 codes from the error logs and decode
+
+`grep "Error: error" filtered-dump.log  > errors`
+
+You can just use vim block edit mode to remove everything except the codes.
+
+`cat errors | uniq > deduped`
+
+`./decode.sh deduped`
+
+#### 3. Lookup actual reminder_codes from postgres and send to cancellation endpoint
+
+Setup the ssh tunnel to the database bastion, then run:
+`node getReminderCode.js <database name> <username> <password> <path-to-file>`

--- a/scripts/recover-cancellations/decode.sh
+++ b/scripts/recover-cancellations/decode.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+while IFS= read -r line; do
+    echo `echo $line | base64 -d`
+done < "$1"
+

--- a/scripts/recover-cancellations/getReminderCode.js
+++ b/scripts/recover-cancellations/getReminderCode.js
@@ -1,0 +1,47 @@
+const pg = require('pg');
+const fs = require('fs');
+const fetch = require('node-fetch');
+
+const database = process.argv[2];
+const user = process.argv[3];
+const password = process.argv[4];
+const path = process.argv[5];
+
+const pool = new pg.Pool({
+	host: 'localhost',
+	database,
+	user,
+	password,
+	port: 5431,
+});
+
+const data = fs.readFileSync(path).toString()
+data.split('\n').forEach(prefix => {
+	const query = {
+		text: `
+			WITH codes AS (
+				SELECT reminder_code
+				FROM recurring_reminder_signups
+				UNION
+				SELECT reminder_code
+				FROM one_off_reminder_signups
+			)
+			SELECT reminder_code FROM codes
+			WHERE
+				reminder_code::text LIKE($1)
+        `,
+		values: [`${prefix}%`],
+	};
+
+	pool.query(query)
+		.then(result => {
+			console.log(prefix, result.rows[0].reminder_code)
+			return fetch('https://reminders.support.guardianapis.com/cancel',
+			{
+				method: 'POST',
+				body: JSON.stringify({ reminderCode: result.rows[0].reminder_code} )
+			})
+		}).then(response => {
+			console.log('api response', response.status)
+		})
+})

--- a/scripts/recover-cancellations/package.json
+++ b/scripts/recover-cancellations/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "support-reminders",
+	"dependencies": {
+		"node-fetch": "^2.1.2",
+		"pg": "^7.9.0",
+		"pg-format": "^1.0.4"
+	},
+	"devDependencies": {},
+	"scripts": {}
+}


### PR DESCRIPTION
Due to an issue on the braze side, many cancellations requests failed.
The issue is that the reminder_code in the url path was a truncated base64 version of the actual reminder_code.
The README here documents the steps to replay the cancellations with the correct reminder_codes.