### PR TITLE
Add link to instructions to connect to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ TEST_DB_URL='postgresql://localhost/support-reminders-test'
 ```
 
 Remember to run `nvm use` before running the tests.
+
+## Connecting to the contributions store database
+
+Follow set up instructions in the [contributions-platform](https://github.com/guardian/contributions-platform/tree/master/contributions-store) repo.


### PR DESCRIPTION
Co-authored-by: Tom Pretty <TomPretty@users.noreply.github.com>

## What does this change?
This PR adds a section to the README on how to connect to the contributions store database. We have added a link to the contributions-platform repo where there are set up and connection instructions.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
