### PR TITLE
migrate from old to new stack

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -263,18 +263,15 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::CloudWatch::Alarm",
     },
     "BasePathMapping": {
-      "DependsOn": [
-        "ServerlessRestApiProdStage",
-      ],
       "Properties": {
         "DomainName": {
           "Ref": "DomainName",
         },
         "RestApiId": {
-          "Ref": "ServerlessRestApi",
+          "Ref": "RestApi0C43BF4B",
         },
         "Stage": {
-          "Fn::Sub": "Prod",
+          "Ref": "RestApiDeploymentStageprod3855DE66",
         },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
@@ -698,19 +695,8 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
     },
     "DNSRecord": {
       "Properties": {
-        "Comment": {
-          "Fn::Sub": "CNAME for contributions reminders endpoint \${Stage}",
-        },
-        "HostedZoneName": "support.guardianapis.com.",
-        "Name": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "HostedZoneId": "Z3KO35ELNWZMSX",
+        "Name": "reminders-code.support.guardianapis.com",
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
@@ -719,29 +705,30 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "TTL": "120",
+        "TTL": "60",
         "Type": "CNAME",
       },
       "Type": "AWS::Route53::RecordSet",
     },
     "DomainName": {
       "Properties": {
-        "DomainName": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "DomainName": "reminders-code.support.guardianapis.com",
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL",
           ],
         },
         "RegionalCertificateArn": {
-          "Ref": "CertificateArn",
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+            ],
+          ],
         },
         "Tags": [
           {
@@ -5188,18 +5175,15 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::CloudWatch::Alarm",
     },
     "BasePathMapping": {
-      "DependsOn": [
-        "ServerlessRestApiProdStage",
-      ],
       "Properties": {
         "DomainName": {
           "Ref": "DomainName",
         },
         "RestApiId": {
-          "Ref": "ServerlessRestApi",
+          "Ref": "RestApi0C43BF4B",
         },
         "Stage": {
-          "Fn::Sub": "Prod",
+          "Ref": "RestApiDeploymentStageprod3855DE66",
         },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
@@ -5623,19 +5607,8 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
     },
     "DNSRecord": {
       "Properties": {
-        "Comment": {
-          "Fn::Sub": "CNAME for contributions reminders endpoint \${Stage}",
-        },
-        "HostedZoneName": "support.guardianapis.com.",
-        "Name": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "HostedZoneId": "Z3KO35ELNWZMSX",
+        "Name": "reminders.support.guardianapis.com",
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
@@ -5644,29 +5617,30 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "TTL": "120",
+        "TTL": "60",
         "Type": "CNAME",
       },
       "Type": "AWS::Route53::RecordSet",
     },
     "DomainName": {
       "Properties": {
-        "DomainName": {
-          "Fn::FindInMap": [
-            "StageMap",
-            {
-              "Ref": "Stage",
-            },
-            "DomainName",
-          ],
-        },
+        "DomainName": "reminders.support.guardianapis.com",
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL",
           ],
         },
         "RegionalCertificateArn": {
-          "Ref": "CertificateArn",
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+            ],
+          ],
         },
         "Tags": [
           {

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -171,31 +171,31 @@ export class SupportReminders extends GuStack {
 
 
 		// ---- DNS ---- //
-		// const certificateArn = `arn:aws:acm:eu-west-1:${this.account}:certificate/${props.certificateId}`;
-		//
-		// const cfnDomainName = new CfnDomainName(this, "DomainName", {
-		// 	domainName: props.domainName,
-		// 	regionalCertificateArn: certificateArn,
-		// 	endpointConfiguration: {
-		// 		types: ["REGIONAL"]
-		// 	}
-		// });
-		//
-		// new CfnBasePathMapping(this, "BasePathMapping", {
-		// 	domainName: cfnDomainName.ref,
-		// 	restApiId: supportRemindersApi.api.restApiId,
-		// 	stage: supportRemindersApi.api.deploymentStage.stageName,
-		// });
-		//
-		// new CfnRecordSet(this, "DNSRecord", {
-		// 	name: props.domainName,
-		// 	type: "CNAME",
-		// 	hostedZoneId: props.hostedZoneId,
-		// 	ttl: "60",
-		// 	resourceRecords: [
-		// 		cfnDomainName.attrRegionalDomainName
-		// 	],
-		// });
+		const certificateArn = `arn:aws:acm:eu-west-1:${this.account}:certificate/${props.certificateId}`;
+
+		const cfnDomainName = new CfnDomainName(this, "DomainName", {
+			domainName: props.domainName,
+			regionalCertificateArn: certificateArn,
+			endpointConfiguration: {
+				types: ["REGIONAL"]
+			}
+		});
+
+		new CfnBasePathMapping(this, "BasePathMapping", {
+			domainName: cfnDomainName.ref,
+			restApiId: supportRemindersApi.api.restApiId,
+			stage: supportRemindersApi.api.deploymentStage.stageName,
+		});
+
+		new CfnRecordSet(this, "DNSRecord", {
+			name: props.domainName,
+			type: "CNAME",
+			hostedZoneId: props.hostedZoneId,
+			ttl: "60",
+			resourceRecords: [
+				cfnDomainName.attrRegionalDomainName
+			],
+		});
 
 
 		// ---- Apply policies ---- //

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -202,19 +202,19 @@ Resources:
         Fn::GetAtt:
           - NextRemindersLambdaSchedule
           - Arn
-  DomainName:
-    Type: AWS::ApiGateway::DomainName
-    Properties:
-      RegionalCertificateArn:
-        Ref: CertificateArn
-      DomainName:
-        Fn::FindInMap:
-          - StageMap
-          - Ref: Stage
-          - DomainName
-      EndpointConfiguration:
-        Types:
-          - REGIONAL
+#  DomainName:
+#    Type: AWS::ApiGateway::DomainName
+#    Properties:
+#      RegionalCertificateArn:
+#        Ref: CertificateArn
+#      DomainName:
+#        Fn::FindInMap:
+#          - StageMap
+#          - Ref: Stage
+#          - DomainName
+#      EndpointConfiguration:
+#        Types:
+#          - REGIONAL
   NextRemindersLambdaSchedule:
     Type: AWS::Events::Rule
     Properties:
@@ -379,23 +379,23 @@ Resources:
       Tags:
         - Key: lambda:createdBy
           Value: SAM
-  DNSRecord:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneName: support.guardianapis.com.
-      Name:
-        Fn::FindInMap:
-          - StageMap
-          - Ref: Stage
-          - DomainName
-      Comment:
-        Fn::Sub: CNAME for contributions reminders endpoint ${Stage}
-      Type: CNAME
-      TTL: '120'
-      ResourceRecords:
-        - Fn::GetAtt:
-            - DomainName
-            - RegionalDomainName
+#  DNSRecord:
+#    Type: AWS::Route53::RecordSet
+#    Properties:
+#      HostedZoneName: support.guardianapis.com.
+#      Name:
+#        Fn::FindInMap:
+#          - StageMap
+#          - Ref: Stage
+#          - DomainName
+#      Comment:
+#        Fn::Sub: CNAME for contributions reminders endpoint ${Stage}
+#      Type: CNAME
+#      TTL: '120'
+#      ResourceRecords:
+#        - Fn::GetAtt:
+#            - DomainName
+#            - RegionalDomainName
   ServerlessRestApiDeployment35164ab9c6:
     Type: AWS::ApiGateway::Deployment
     Properties:
@@ -636,16 +636,16 @@ Resources:
       Tags:
         - Key: lambda:createdBy
           Value: SAM
-  BasePathMapping:
-    Type: AWS::ApiGateway::BasePathMapping
-    Properties:
-      RestApiId:
-        Ref: ServerlessRestApi
-      DomainName:
-        Ref: DomainName
-      Stage:
-        Fn::Sub: Prod
-    DependsOn: ServerlessRestApiProdStage
+#  BasePathMapping:
+#    Type: AWS::ApiGateway::BasePathMapping
+#    Properties:
+#      RestApiId:
+#        Ref: ServerlessRestApi
+#      DomainName:
+#        Ref: DomainName
+#      Stage:
+#        Fn::Sub: Prod
+#    DependsOn: ServerlessRestApiProdStage
   CreateReminderSignupLambdaCreateRecurringPermissionProd:
     Type: AWS::Lambda::Permission
     Properties:


### PR DESCRIPTION
This PR updates DNS and path mapping to serve CDK-provisioned infrastructure. Once this has been merged and tested we can tear down the old resources. If any issues arise, we can easily revert to the previous state by reverting this PR.