### PR TITLE
Return a 400 if Identity guest creation errors on a long email address

### DIFF
--- a/src/create-reminder-signup/lambda/models.ts
+++ b/src/create-reminder-signup/lambda/models.ts
@@ -2,7 +2,7 @@ import {
 	createDetailedValidator,
 	registerType,
 } from 'typecheck.macro/dist/typecheck.macro';
-import { isValidEmail } from '../../lib/models';
+import { emailIsShortEnoughForIdentity, isValidEmail } from '../../lib/models';
 
 // Database model
 export interface BaseSignup {
@@ -64,7 +64,11 @@ export const oneOffSignupValidator = createDetailedValidator<OneOffSignupRequest
 	{
 		constraints: {
 			Email: (email: string) =>
-				isValidEmail(email) ? null : 'Invalid email',
+				!isValidEmail(email)
+					? 'Invalid email address'
+					: !emailIsShortEnoughForIdentity(email)
+					? 'Email address is too long'
+					: null,
 			DateString: (dateString: string) =>
 				isValidDateString(dateString) ? null : 'Invalid date',
 		},
@@ -77,7 +81,11 @@ export const recurringSignupValidator = createDetailedValidator<RecurringSignupR
 	{
 		constraints: {
 			Email: (email: string) =>
-				isValidEmail(email) ? null : 'Invalid email',
+				!isValidEmail(email)
+					? 'Invalid email address'
+					: !emailIsShortEnoughForIdentity(email)
+					? 'Email address is too long'
+					: null,
 			DateString: (dateString: string) =>
 				isValidDateString(dateString) ? null : 'Invalid date',
 		},

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -11,4 +11,10 @@ export function isValidEmail(email: string): boolean {
 	return re.test(email.toLowerCase());
 }
 
+export function emailIsShortEnoughForIdentity(email: string): boolean {
+	// Identity’s guest creation endpoint errors if the provided email address
+	// is more than 100 characters long
+	return email.length <= 100;
+}
+
 export type ValidationErrors = Array<[string, unknown, IR.IR | string]>;


### PR DESCRIPTION
Identity can’t handle addresses longer than 100 characters in its guest creation endpoint, and returns a 500. Since we don’t want alerts in this case, but we do want alerts on 500s, this change returns a 400 instead.

I also considered blocking email addresses that long up front in the email validation, but wondered about the possibility that someone might successfully create a non-guest Identity account with an email address that long, and then try to set a reminder: then we’d incorrectly fail the validation.

Also, doing it after the call to Identity means that if they fix the guest creation endpoint so it can handle email addresses that long, we won’t be blocking them.

Trello card: https://trello.com/c/An7oJD1k/410-stop-alarms-on-bad-email-addresses-for-support-reminders

The address `bob@127.0.0.1` mentioned in the card doesn’t cause any problems in my testing, so I think it’s been handled on Identity’s end.
