### PR TITLE
Add unit tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ jobs:
       contents: read
     name: support-reminders build
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Env
         run: env
@@ -41,6 +53,13 @@ jobs:
 
       - name: Build project and generate Riff-Raff artefact
         run: ./script/ci.sh
+
+      - name: Run unit tests
+        run: yarn test --silent
+        env:
+          TEST_DB_URL: postgresql://localhost/postgres
+          TEST_DB_USER: postgres
+          TEST_DB_PASSWORD: postgres
 
       - name: Generate CFN templates from GuCDK
         run: ./script/cfn.sh


### PR DESCRIPTION
The unit tests haven’t been run in CI before, which we think is because it took some effort to get postgres working with TeamCity. Now that CI is running in Github Actions, it’s straightforward enough to do using a service container. 

I’ve also silenced the test logging, because the output was very noisy: it’s much easier to see the test passes and failures this way.

Trello card: https://trello.com/c/1FPxTLxm/984-add-unit-tests-to-ci-workflow-on-support-reminders-repo