### PR TITLE
Support signups from emails

### DIFF
--- a/src/create-reminder-signup/lambda/models.ts
+++ b/src/create-reminder-signup/lambda/models.ts
@@ -22,9 +22,14 @@ export interface RecurringSignup extends BaseSignup {
 }
 
 // API request models
-export type ReminderPlatform = 'WEB' | 'AMP' | 'MMA' | 'SUPPORT';
+export type ReminderPlatform = 'WEB' | 'AMP' | 'MMA' | 'SUPPORT' | 'EMAIL';
 
-export type ReminderComponent = 'EPIC' | 'BANNER' | 'THANKYOU' | 'CANCELLATION';
+export type ReminderComponent =
+	| 'EPIC'
+	| 'BANNER'
+	| 'THANKYOU'
+	| 'CANCELLATION'
+	| 'EMAIL';
 
 export type ReminderStage = 'PRE' | 'POST' | 'WINBACK';
 


### PR DESCRIPTION
We're enabling signups from a cta in braze emails.

The `ReminderComponent` field isn't very meaningful here, so it'll be the same as the `ReminderPlatform` - `EMAIL`