### PR TITLE
Switch primary key and unique constraint on reminder tables to enable data warehousing via Fivetran

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -1372,7 +1372,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -1602,7 +1602,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -1832,7 +1832,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -2207,7 +2207,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -2437,7 +2437,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -4158,7 +4158,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -4388,7 +4388,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -4618,7 +4618,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -4993,7 +4993,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",
@@ -5223,7 +5223,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -32,7 +32,7 @@ export class SupportReminders extends GuStack {
 		// ---- Miscellaneous constants ---- //
 		const app = "support-reminders";
 		const vpc = GuVpc.fromIdParameter(this, "vpc");
-		const runtime = Runtime.NODEJS_12_X;
+		const runtime = Runtime.NODEJS_14_X;
 		const fileName = "support-reminders.zip";
 		const environment = {
 			"Bucket": props.datalakeBucket,

--- a/sql/create-signups-tables.sql
+++ b/sql/create-signups-tables.sql
@@ -14,7 +14,7 @@ CREATE TABLE one_off_reminder_signups(
   reminder_code uuid NOT NULL PRIMARY KEY DEFAULT uuid_generate_v4 (),
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-  UNIQUE KEY (identity_id, reminder_period)
+  UNIQUE (identity_id, reminder_period)
 );
 
 /* PostgreSQL automatically creates a unique index when a unique constraint or primary key is defined for a table

--- a/sql/create-signups-tables.sql
+++ b/sql/create-signups-tables.sql
@@ -11,17 +11,20 @@ CREATE TABLE one_off_reminder_signups(
   reminder_stage TEXT NOT NULL,
   reminder_period DATE NOT NULL,
   reminder_option TEXT,
-  reminder_code uuid NOT NULL UNIQUE DEFAULT uuid_generate_v4 (),
+  reminder_code uuid NOT NULL PRIMARY KEY DEFAULT uuid_generate_v4 (),
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-  PRIMARY KEY (identity_id, reminder_period)
+  UNIQUE KEY (identity_id, reminder_period)
 );
 
-CREATE INDEX one_off_reminder_signups_reminder_code ON one_off_reminder_signups (reminder_code);
+/* PostgreSQL automatically creates a unique index when a unique constraint or primary key is defined for a table
+   - https://www.postgresql.org/docs/current/indexes-unique.html
+ */
+-- CREATE INDEX one_off_reminder_signups_reminder_code ON one_off_reminder_signups (identity_id);
 
 DROP TABLE IF EXISTS recurring_reminder_signups;
 CREATE TABLE recurring_reminder_signups(
-  identity_id TEXT NOT NULL PRIMARY KEY,
+  identity_id TEXT NOT NULL UNIQUE,
   country TEXT,
   reminder_created_at TIMESTAMP NOT NULL,
   reminder_cancelled_at TIMESTAMP,
@@ -30,12 +33,15 @@ CREATE TABLE recurring_reminder_signups(
   reminder_stage TEXT NOT NULL,
   reminder_frequency_months INT NOT NULL,
   reminder_option TEXT,
-  reminder_code uuid NOT NULL UNIQUE DEFAULT uuid_generate_v4 (),
+  reminder_code uuid NOT NULL PRIMARY KEY DEFAULT uuid_generate_v4 (),
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX recurring_reminder_signups_reminder_code ON recurring_reminder_signups (reminder_code);
+/* PostgreSQL automatically creates a unique index when a unique constraint or primary key is defined for a table
+   - https://www.postgresql.org/docs/current/indexes-unique.html
+ */
+-- CREATE INDEX recurring_reminder_signups_reminder_code ON recurring_reminder_signups (identity_id);
 
 CREATE OR REPLACE FUNCTION set_updated_at_column()
 RETURNS TRIGGER AS $$

--- a/src/create-reminder-signup/lib/db.ts
+++ b/src/create-reminder-signup/lib/db.ts
@@ -20,7 +20,7 @@ export function writeOneOffSignup(
 			) VALUES (
 				$1, $2, $3, $4, $5, $6, $7, $8
 			)
-			ON CONFLICT ON CONSTRAINT one_off_reminder_signups_pkey
+			ON CONFLICT ON CONSTRAINT one_off_reminder_signups_identity_id_reminder_period_key
 			DO
 				UPDATE SET
 					country = $2,
@@ -65,7 +65,7 @@ export function writeRecurringSignup(
 			) VALUES (
 				$1, $2, $3, $4, $5, $6, $7, $8
 			)
-			ON CONFLICT ON CONSTRAINT recurring_reminder_signups_pkey
+			ON CONFLICT ON CONSTRAINT recurring_reminder_signups_identity_id_key
 			DO
 				UPDATE SET
 					country = $2,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Fivetran cannot extract the reminder tables when the primary key is a string or compound key and not a UUID. 

<img width="426" alt="Screenshot 2023-07-20 at 16 59 35" src="https://github.com/guardian/support-reminders/assets/1515970/a748a1d8-346f-4b25-8479-1afa9591abee">

This PR switches them round. The ALTER statements which apply the changes are below, but the table definitions have been updated in the code instead.

```
ALTER TABLE recurring_reminder_signups DROP CONSTRAINT recurring_reminder_signups_pkey;
ALTER TABLE recurring_reminder_signups DROP CONSTRAINT recurring_reminder_signups_reminder_code_key;
ALTER TABLE recurring_reminder_signups ADD PRIMARY KEY (reminder_code);
ALTER TABLE recurring_reminder_signups ADD UNIQUE (identity_id);

ALTER TABLE one_off_reminder_signups DROP CONSTRAINT one_off_reminder_signups_pkey;
ALTER TABLE one_off_reminder_signups DROP CONSTRAINT one_off_reminder_signups_reminder_code_key;
ALTER TABLE one_off_reminder_signups ADD PRIMARY KEY (reminder_code);
ALTER TABLE one_off_reminder_signups ADD UNIQUE (identity_id, reminder_period);
```

I've upgraded to Node 14 in order for this to be deployable again, I'll raise a ticket on the relevant backlog to upgrade this app to Node 18.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested on CODE. I created test tables from the 2 new definitions and ran the insert/on conflict statements against the new index names, testing the update applied on the right conflict.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

- [x] Fivetran is able to extract the tables in CODE 
<img width="610" alt="Screenshot 2023-07-20 at 15 31 47" src="https://github.com/guardian/support-reminders/assets/1515970/cfe74603-6dc9-41f8-9051-e35fcabbbe8d">

<img width="615" alt="Screenshot 2023-07-20 at 15 32 02" src="https://github.com/guardian/support-reminders/assets/1515970/bcf2c909-2627-4e39-91f7-c074cdb0931b">

- [ ] and PROD

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
Due to the index renaming repeat Reminders will stop being set, so:

- [x] Negative test on main branch to prove this - setting reminders twice on thank you page will fail
- [x] Deploy this branch on CODE - setting reminders twice on thank you page will pass

Trello:

- https://trello.com/c/RWrrf0ln