### PR TITLE
Remove dependabot exclusions from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,22 +56,13 @@ jobs:
           TEST_DB_PASSWORD: postgres
 
       - name: Copy files to Riff Raff package
-        if: >-
-          github.actor != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'dependabot[bot]'
         run: cp package.json riff-raff.yaml target
 
       - name: Yarn install in package
-        if: >-
-          github.actor != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'dependabot[bot]'
         working-directory: ./target
         run: yarn install --production
 
       - name: Zip target directory contents (quietly)
-        if: >-
-          github.actor != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'dependabot[bot]'
         run: zip -qr ../support-reminders.zip ./*
         working-directory: ./target
 
@@ -84,26 +75,17 @@ jobs:
           yarn test
 
       - name: Yarn synth (CDK)
-        if: >-
-          github.actor != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'dependabot[bot]'
         working-directory: cdk
         run: yarn synth
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
-        if: >-
-          github.actor != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'dependabot[bot]'
         with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v2
-        if: >-
-          github.actor != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'dependabot[bot]'
         with:
           app: support-reminders
           configPath: ./riff-raff.yaml
@@ -113,6 +95,3 @@ jobs:
               - ./cdk/cdk.out/SupportReminders-PROD.template.json
             support-reminders:
               - ./support-reminders.zip
-
-
-


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes the dependabot exclusions from the CI workflow so we can deploy dependabot PRs to CODE to test.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

See that builds are available in riff-raff

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
