### PR TITLE
Reminder signup retries

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5035da6977c4856434612951500156443fc": {
+    "RestApiDeployment180EC503822a9b98d6d6bc279f6d05209afc37f8": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -359,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5035da6977c4856434612951500156443fc",
+          "Ref": "RestApiDeployment180EC503822a9b98d6d6bc279f6d05209afc37f8",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -678,7 +678,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{"X-GU-GeoIP-Country-Code":{"DataType":"String","StringValue":"{$request.header.X-GU-GeoIP-Country-Code}"}}"",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')",
           },
           "Type": "AWS",
           "Uri": {
@@ -3036,7 +3036,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5037ee5c5e4dca39cd3423fa8d3467b35cc": {
+    "RestApiDeployment180EC50320cdebac9b37e39b389b3eb4d6ef1260": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3063,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5037ee5c5e4dca39cd3423fa8d3467b35cc",
+          "Ref": "RestApiDeployment180EC50320cdebac9b37e39b389b3eb4d6ef1260",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3382,7 +3382,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{"X-GU-GeoIP-Country-Code":{"DataType":"String","StringValue":"{$request.header.X-GU-GeoIP-Country-Code}"}}"",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -47,6 +47,32 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
     },
+    "apiEndpoint9349E63C": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "apiC8550315",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "apiDeploymentStageprod896C8101",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
   },
   "Parameters": {
     "DistributionBucketName": {
@@ -177,6 +203,71 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGatewayToSqsRole590217A3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiGatewayToSqsRoleDefaultPolicy4DC2F8A9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiGatewayToSqsRoleDefaultPolicy4DC2F8A9",
+        "Roles": [
+          {
+            "Ref": "ApiGatewayToSqsRole590217A3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "BasePathMapping": {
       "Properties": {
@@ -1342,6 +1433,245 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SendMessagePolicyDCAA5B79": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SendMessagePolicyDCAA5B79",
+        "Roles": [
+          {
+            "Ref": "createreminderssignupServiceRole14AD0F8F",
+          },
+          {
+            "Ref": "reactivaterecurringreminderServiceRoleA9652C4C",
+          },
+          {
+            "Ref": "cancelremindersServiceRole2D334903",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "apiAccount57E28B43": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "apiC8550315",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "apiCloudWatchRoleAC81D93E",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "apiC8550315": {
+      "Properties": {
+        "Name": "api",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "apiCloudWatchRoleAC81D93E": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "apiDeployment149F129446765f02adb599bbbfd06ebca9169f38": {
+      "DependsOn": [
+        "apiPOST36368FF5",
+      ],
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "apiC8550315",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "apiDeploymentStageprod896C8101": {
+      "DependsOn": [
+        "apiAccount57E28B43",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "apiDeployment149F129446765f02adb599bbbfd06ebca9169f38",
+        },
+        "RestApiId": {
+          "Ref": "apiC8550315",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "apiPOST36368FF5": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayToSqsRole590217A3",
+              "Arn",
+            ],
+          },
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": [
+            {
+              "ResponseTemplates": {
+                "application/json": "{"done": true}",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
+          },
+          "RequestTemplates": {
+            "application/json": "Action=SendMessage&MessageBody=$input.body",
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":sqs:path/",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                "/",
+                {
+                  "Fn::GetAtt": [
+                    "supportremindersQueue01C5AB8D",
+                    "QueueName",
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "MethodResponses": [
+          {
+            "StatusCode": "200",
+          },
+        ],
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "apiC8550315",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "apiC8550315",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "cancelremindersF4DAF18B": {
       "DependsOn": [
         "cancelremindersServiceRoleDefaultPolicyC48CB67C",
@@ -1478,6 +1808,22 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -1571,6 +1917,23 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "cancelremindersSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B46367325": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "cancelremindersF4DAF18B",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "createreminderssignupB956888C": {
       "DependsOn": [
@@ -1708,6 +2071,22 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -1801,6 +2180,50 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "createreminderssignupSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9BE219E9BA": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "createreminderssignupB956888C",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "deadletterssupportremindersQueue83E67347": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": "dead-letters-support-reminders-CODE",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
     "nextreminders1BF0BB76": {
       "DependsOn": [
@@ -2046,6 +2469,22 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2139,6 +2578,23 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "nextremindersSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B6DC73DA8": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "nextreminders1BF0BB76",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "nextremindersnextreminderscron05000AllowEventRuleSupportRemindersCODEnextremindersCEEC74A609E30C1C": {
       "Properties": {
@@ -2313,6 +2769,22 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2406,6 +2878,23 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "reactivaterecurringreminderSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B8D3D30D2": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "reactivaterecurringreminder0045F57B",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "signupexportsDBFAB572": {
       "DependsOn": [
@@ -2651,6 +3140,22 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2745,6 +3250,23 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "signupexportsSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B89F70850": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "signupexportsDBFAB572",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
     "signupexportssignupexportscron05000AADDEB89": {
       "Properties": {
         "ScheduleExpression": "cron(05 00 * * ? *)",
@@ -2781,6 +3303,42 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "supportremindersQueue01C5AB8D": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "support-reminders-queue-CODE",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "deadletterssupportremindersQueue83E67347",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 1,
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VisibilityTimeout": 120,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }
@@ -2827,6 +3385,32 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "/",
             {
               "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+    "apiEndpoint9349E63C": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "apiC8550315",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "apiDeploymentStageprod896C8101",
             },
             "/",
           ],
@@ -2963,6 +3547,71 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGatewayToSqsRole590217A3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiGatewayToSqsRoleDefaultPolicy4DC2F8A9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiGatewayToSqsRoleDefaultPolicy4DC2F8A9",
+        "Roles": [
+          {
+            "Ref": "ApiGatewayToSqsRole590217A3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "BasePathMapping": {
       "Properties": {
@@ -4128,6 +4777,245 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SendMessagePolicyDCAA5B79": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SendMessagePolicyDCAA5B79",
+        "Roles": [
+          {
+            "Ref": "createreminderssignupServiceRole14AD0F8F",
+          },
+          {
+            "Ref": "reactivaterecurringreminderServiceRoleA9652C4C",
+          },
+          {
+            "Ref": "cancelremindersServiceRole2D334903",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "apiAccount57E28B43": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "apiC8550315",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "apiCloudWatchRoleAC81D93E",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "apiC8550315": {
+      "Properties": {
+        "Name": "api",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "apiCloudWatchRoleAC81D93E": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "apiDeployment149F1294461bea2efd612aad2761d2d18c877942": {
+      "DependsOn": [
+        "apiPOST36368FF5",
+      ],
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "apiC8550315",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "apiDeploymentStageprod896C8101": {
+      "DependsOn": [
+        "apiAccount57E28B43",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "apiDeployment149F1294461bea2efd612aad2761d2d18c877942",
+        },
+        "RestApiId": {
+          "Ref": "apiC8550315",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "apiPOST36368FF5": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayToSqsRole590217A3",
+              "Arn",
+            ],
+          },
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": [
+            {
+              "ResponseTemplates": {
+                "application/json": "{"done": true}",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
+          },
+          "RequestTemplates": {
+            "application/json": "Action=SendMessage&MessageBody=$input.body",
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":sqs:path/",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                "/",
+                {
+                  "Fn::GetAtt": [
+                    "supportremindersQueue01C5AB8D",
+                    "QueueName",
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "MethodResponses": [
+          {
+            "StatusCode": "200",
+          },
+        ],
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "apiC8550315",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "apiC8550315",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "cancelremindersF4DAF18B": {
       "DependsOn": [
         "cancelremindersServiceRoleDefaultPolicyC48CB67C",
@@ -4264,6 +5152,22 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -4357,6 +5261,23 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "cancelremindersSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82CF609D22": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "cancelremindersF4DAF18B",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "createreminderssignupB956888C": {
       "DependsOn": [
@@ -4494,6 +5415,22 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -4587,6 +5524,50 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "createreminderssignupSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82167501E9": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "createreminderssignupB956888C",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "deadletterssupportremindersQueue83E67347": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": "dead-letters-support-reminders-PROD",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
     "nextreminders1BF0BB76": {
       "DependsOn": [
@@ -4832,6 +5813,22 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -4925,6 +5922,23 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "nextremindersSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D829B3BB3C8": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "nextreminders1BF0BB76",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "nextremindersnextreminderscron05000AllowEventRuleSupportRemindersPRODnextreminders3B36D5FC8C6A0FB9": {
       "Properties": {
@@ -5099,6 +6113,22 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -5192,6 +6222,23 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "reactivaterecurringreminderSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82899AD062": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "reactivaterecurringreminder0045F57B",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "signupexportsDBFAB572": {
       "DependsOn": [
@@ -5437,6 +6484,22 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "supportremindersQueue01C5AB8D",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -5531,6 +6594,23 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "signupexportsSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82BEF93D9D": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "supportremindersQueue01C5AB8D",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "signupexportsDBFAB572",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
     "signupexportssignupexportscron05000AADDEB89": {
       "Properties": {
         "ScheduleExpression": "cron(05 00 * * ? *)",
@@ -5567,6 +6647,42 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "supportremindersQueue01C5AB8D": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "support-reminders-queue-PROD",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "deadletterssupportremindersQueue83E67347",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 1,
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VisibilityTimeout": 120,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50343807d8a1a99709b81cdc7eaa1149c19": {
+    "RestApiDeployment180EC5039c80d31f10d754c73477b31ff9c1d8b8": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -359,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50343807d8a1a99709b81cdc7eaa1149c19",
+          "Ref": "RestApiDeployment180EC5039c80d31f10d754c73477b31ff9c1d8b8",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -678,7 +678,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"Signature\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"\${request.header.signature}\\"}}"",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes=$input.header",
           },
           "Type": "AWS",
           "Uri": {
@@ -3036,7 +3036,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503a868804856ab22461679815c45cf88b7": {
+    "RestApiDeployment180EC503032a269da8e416e640a8b575e8ee0dc6": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3063,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503a868804856ab22461679815c45cf88b7",
+          "Ref": "RestApiDeployment180EC503032a269da8e416e640a8b575e8ee0dc6",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3382,7 +3382,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"Signature\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"\${request.header.signature}\\"}}"",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes=$input.header",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -406,13 +406,15 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27": {
+    "RestApiDeployment180EC503028aa5ded9001e8322ed3e4ea52560d6": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
+        "RestApicreateoneOPTIONS6F9500E1",
+        "RestApicreateonePOST9B86A777",
+        "RestApicreateoneC363A09F",
         "RestApicreateOPTIONSC3837E5E",
-        "RestApicreatePOST89063740",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -433,7 +435,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27",
+          "Ref": "RestApiDeployment180EC503028aa5ded9001e8322ed3e4ea52560d6",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -728,7 +730,58 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreatePOST89063740": {
+    "RestApicreateoneC363A09F": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApicreate68AA2AF0",
+        },
+        "PathPart": "one-",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApicreateoneOPTIONS6F9500E1": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreateoneC363A09F",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreateonePOST9B86A777": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -788,7 +841,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           },
         ],
         "ResourceId": {
-          "Ref": "RestApicreate68AA2AF0",
+          "Ref": "RestApicreateoneC363A09F",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -1300,22 +1353,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -1409,23 +1446,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "cancelremindersSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B46367325": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "cancelremindersF4DAF18B",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "createreminderssignupB956888C": {
       "DependsOn": [
@@ -1961,22 +1981,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2070,23 +2074,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "nextremindersSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B6DC73DA8": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "nextreminders1BF0BB76",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "nextremindersnextreminderscron05000AllowEventRuleSupportRemindersCODEnextremindersCEEC74A609E30C1C": {
       "Properties": {
@@ -2261,22 +2248,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2370,23 +2341,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "reactivaterecurringreminderSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B8D3D30D2": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "reactivaterecurringreminder0045F57B",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "signupexportsDBFAB572": {
       "DependsOn": [
@@ -2632,22 +2586,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2741,23 +2679,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "signupexportsSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9B89F70850": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "signupexportsDBFAB572",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "signupexportssignupexportscron05000AADDEB89": {
       "Properties": {
@@ -3242,13 +3163,15 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266": {
+    "RestApiDeployment180EC5035a364e18e9e867b453b010c0b4c9414e": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
+        "RestApicreateoneOPTIONS6F9500E1",
+        "RestApicreateonePOST9B86A777",
+        "RestApicreateoneC363A09F",
         "RestApicreateOPTIONSC3837E5E",
-        "RestApicreatePOST89063740",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -3269,7 +3192,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266",
+          "Ref": "RestApiDeployment180EC5035a364e18e9e867b453b010c0b4c9414e",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3564,7 +3487,58 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreatePOST89063740": {
+    "RestApicreateoneC363A09F": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApicreate68AA2AF0",
+        },
+        "PathPart": "one-",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApicreateoneOPTIONS6F9500E1": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreateoneC363A09F",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreateonePOST9B86A777": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -3624,7 +3598,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           },
         ],
         "ResourceId": {
-          "Ref": "RestApicreate68AA2AF0",
+          "Ref": "RestApicreateoneC363A09F",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -4136,22 +4110,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -4245,23 +4203,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "cancelremindersSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82CF609D22": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "cancelremindersF4DAF18B",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "createreminderssignupB956888C": {
       "DependsOn": [
@@ -4797,22 +4738,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -4906,23 +4831,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "nextremindersSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D829B3BB3C8": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "nextreminders1BF0BB76",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "nextremindersnextreminderscron05000AllowEventRuleSupportRemindersPRODnextreminders3B36D5FC8C6A0FB9": {
       "Properties": {
@@ -5097,22 +5005,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -5206,23 +5098,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "reactivaterecurringreminderSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82899AD062": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "reactivaterecurringreminder0045F57B",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "signupexportsDBFAB572": {
       "DependsOn": [
@@ -5468,22 +5343,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           "Statement": [
             {
               "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "supportremindersQueue01C5AB8D",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -5577,23 +5436,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "signupexportsSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82BEF93D9D": {
-      "Properties": {
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "supportremindersQueue01C5AB8D",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "signupexportsDBFAB572",
-        },
-        "FunctionResponseTypes": [
-          "ReportBatchItemFailures",
-        ],
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "signupexportssignupexportscron05000AADDEB89": {
       "Properties": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27": {
+    "RestApiDeployment180EC50343807d8a1a99709b81cdc7eaa1149c19": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -359,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27",
+          "Ref": "RestApiDeployment180EC50343807d8a1a99709b81cdc7eaa1149c19",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -678,7 +678,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"Signature\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"\${request.header.signature}\\"}}"",
           },
           "Type": "AWS",
           "Uri": {
@@ -3036,7 +3036,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266": {
+    "RestApiDeployment180EC503a868804856ab22461679815c45cf88b7": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3063,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266",
+          "Ref": "RestApiDeployment180EC503a868804856ab22461679815c45cf88b7",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3382,7 +3382,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"Signature\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"\${request.header.signature}\\"}}"",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5039c80d31f10d754c73477b31ff9c1d8b8": {
+    "RestApiDeployment180EC5038818785ffe56af03055de428c5fa4793": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -359,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5039c80d31f10d754c73477b31ff9c1d8b8",
+          "Ref": "RestApiDeployment180EC5038818785ffe56af03055de428c5fa4793",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -678,7 +678,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes=$input.header",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=Headers&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header)",
           },
           "Type": "AWS",
           "Uri": {
@@ -3036,7 +3036,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503032a269da8e416e640a8b575e8ee0dc6": {
+    "RestApiDeployment180EC50335deeadc51cca2b968b76e3f8bf25bcf": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3063,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503032a269da8e416e640a8b575e8ee0dc6",
+          "Ref": "RestApiDeployment180EC50335deeadc51cca2b968b76e3f8bf25bcf",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3382,7 +3382,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes=$input.header",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=Headers&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header)",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,15 +332,13 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503028aa5ded9001e8322ed3e4ea52560d6": {
+    "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
-        "RestApicreateoneOPTIONS6F9500E1",
-        "RestApicreateonePOST9B86A777",
-        "RestApicreateoneC363A09F",
         "RestApicreateOPTIONSC3837E5E",
+        "RestApicreatePOST89063740",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -361,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503028aa5ded9001e8322ed3e4ea52560d6",
+          "Ref": "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -656,58 +654,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreateoneC363A09F": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApicreate68AA2AF0",
-        },
-        "PathPart": "one-",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApicreateoneOPTIONS6F9500E1": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": {
-          "Ref": "RestApicreateoneC363A09F",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreateonePOST9B86A777": {
+    "RestApicreatePOST89063740": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -767,7 +714,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           },
         ],
         "ResourceId": {
-          "Ref": "RestApicreateoneC363A09F",
+          "Ref": "RestApicreate68AA2AF0",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3089,15 +3036,13 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5035a364e18e9e867b453b010c0b4c9414e": {
+    "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
-        "RestApicreateoneOPTIONS6F9500E1",
-        "RestApicreateonePOST9B86A777",
-        "RestApicreateoneC363A09F",
         "RestApicreateOPTIONSC3837E5E",
+        "RestApicreatePOST89063740",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -3118,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5035a364e18e9e867b453b010c0b4c9414e",
+          "Ref": "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3413,58 +3358,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreateoneC363A09F": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApicreate68AA2AF0",
-        },
-        "PathPart": "one-",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApicreateoneOPTIONS6F9500E1": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": {
-          "Ref": "RestApicreateoneC363A09F",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreateonePOST9B86A777": {
+    "RestApicreatePOST89063740": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -3524,7 +3418,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           },
         ],
         "ResourceId": {
-          "Ref": "RestApicreateoneC363A09F",
+          "Ref": "RestApicreate68AA2AF0",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5034ee94a05b01318d21ec1502ec4a7ca7f": {
+    "RestApiDeployment180EC5035da6977c4856434612951500156443fc": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -359,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5034ee94a05b01318d21ec1502ec4a7ca7f",
+          "Ref": "RestApiDeployment180EC5035da6977c4856434612951500156443fc",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -678,7 +678,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"X-GU-GeoIP-Country-Code\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"{$request.header.X-GU-GeoIP-Country-Code}\\"}}"",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{"X-GU-GeoIP-Country-Code":{"DataType":"String","StringValue":"{$request.header.X-GU-GeoIP-Country-Code}"}}"",
           },
           "Type": "AWS",
           "Uri": {
@@ -3036,7 +3036,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50356cf38bcadde9d3b261e0b6486023421": {
+    "RestApiDeployment180EC5037ee5c5e4dca39cd3423fa8d3467b35cc": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3063,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50356cf38bcadde9d3b261e0b6486023421",
+          "Ref": "RestApiDeployment180EC5037ee5c5e4dca39cd3423fa8d3467b35cc",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3382,7 +3382,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"X-GU-GeoIP-Country-Code\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"{$request.header.X-GU-GeoIP-Country-Code}\\"}}"",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{"X-GU-GeoIP-Country-Code":{"DataType":"String","StringValue":"{$request.header.X-GU-GeoIP-Country-Code}"}}"",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,13 +332,18 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503822a9b98d6d6bc279f6d05209afc37f8": {
+    "RestApiDeployment180EC503ddd14ce8239bbacaf6192796abf8eb29": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
+        "RestApicreateoneoffOPTIONS1F89A992",
+        "RestApicreateoneoffPOST41A64A32",
+        "RestApicreateoneoff2D1FCD3C",
         "RestApicreateOPTIONSC3837E5E",
-        "RestApicreatePOST89063740",
+        "RestApicreaterecurringOPTIONSFBFDACD1",
+        "RestApicreaterecurringPOSTC2005445",
+        "RestApicreaterecurringA327119C",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -359,7 +364,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503822a9b98d6d6bc279f6d05209afc37f8",
+          "Ref": "RestApiDeployment180EC503ddd14ce8239bbacaf6192796abf8eb29",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -654,7 +659,58 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreatePOST89063740": {
+    "RestApicreateoneoff2D1FCD3C": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApicreate68AA2AF0",
+        },
+        "PathPart": "one-off",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApicreateoneoffOPTIONS1F89A992": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreateoneoff2D1FCD3C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreateoneoffPOST41A64A32": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -678,7 +734,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
           },
           "Type": "AWS",
           "Uri": {
@@ -714,7 +770,126 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           },
         ],
         "ResourceId": {
+          "Ref": "RestApicreateoneoff2D1FCD3C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreaterecurringA327119C": {
+      "Properties": {
+        "ParentId": {
           "Ref": "RestApicreate68AA2AF0",
+        },
+        "PathPart": "recurring",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApicreaterecurringOPTIONSFBFDACD1": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreaterecurringA327119C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreaterecurringPOSTC2005445": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayToSqsRole590217A3",
+              "Arn",
+            ],
+          },
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": [
+            {
+              "ResponseTemplates": {
+                "application/json": "{"done": true}",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
+          },
+          "RequestTemplates": {
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":sqs:path/",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                "/",
+                {
+                  "Fn::GetAtt": [
+                    "supportremindersQueue01C5AB8D",
+                    "QueueName",
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "MethodResponses": [
+          {
+            "StatusCode": "200",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreaterecurringA327119C",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3036,13 +3211,18 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50320cdebac9b37e39b389b3eb4d6ef1260": {
+    "RestApiDeployment180EC503425c8ffd6fd88e79f3cc34e8f8338674": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
+        "RestApicreateoneoffOPTIONS1F89A992",
+        "RestApicreateoneoffPOST41A64A32",
+        "RestApicreateoneoff2D1FCD3C",
         "RestApicreateOPTIONSC3837E5E",
-        "RestApicreatePOST89063740",
+        "RestApicreaterecurringOPTIONSFBFDACD1",
+        "RestApicreaterecurringPOSTC2005445",
+        "RestApicreaterecurringA327119C",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -3063,7 +3243,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50320cdebac9b37e39b389b3eb4d6ef1260",
+          "Ref": "RestApiDeployment180EC503425c8ffd6fd88e79f3cc34e8f8338674",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3358,7 +3538,58 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreatePOST89063740": {
+    "RestApicreateoneoff2D1FCD3C": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApicreate68AA2AF0",
+        },
+        "PathPart": "one-off",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApicreateoneoffOPTIONS1F89A992": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreateoneoff2D1FCD3C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreateoneoffPOST41A64A32": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -3382,7 +3613,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
           },
           "Type": "AWS",
           "Uri": {
@@ -3418,7 +3649,126 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           },
         ],
         "ResourceId": {
+          "Ref": "RestApicreateoneoff2D1FCD3C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreaterecurringA327119C": {
+      "Properties": {
+        "ParentId": {
           "Ref": "RestApicreate68AA2AF0",
+        },
+        "PathPart": "recurring",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApicreaterecurringOPTIONSFBFDACD1": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "StatusCode": "204",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "204",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreaterecurringA327119C",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApicreaterecurringPOSTC2005445": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayToSqsRole590217A3",
+              "Arn",
+            ],
+          },
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": [
+            {
+              "ResponseTemplates": {
+                "application/json": "{"done": true}",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
+          },
+          "RequestTemplates": {
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":sqs:path/",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                "/",
+                {
+                  "Fn::GetAtt": [
+                    "supportremindersQueue01C5AB8D",
+                    "QueueName",
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "MethodResponses": [
+          {
+            "StatusCode": "200",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "RestApicreaterecurringA327119C",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5031f73e9e0881546891a8a5fa8a2a9fff2": {
+    "RestApiDeployment180EC5034ee94a05b01318d21ec1502ec4a7ca7f": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -359,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5031f73e9e0881546891a8a5fa8a2a9fff2",
+          "Ref": "RestApiDeployment180EC5034ee94a05b01318d21ec1502ec4a7ca7f",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -678,7 +678,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=X-GU-GeoIP-Country-Code&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header.get('X-GU-GeoIP-Country-Code'))",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"X-GU-GeoIP-Country-Code\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"{$request.header.X-GU-GeoIP-Country-Code}\\"}}"",
           },
           "Type": "AWS",
           "Uri": {
@@ -3036,7 +3036,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503bd5136ffa144d5464a103ca98d81d905": {
+    "RestApiDeployment180EC50356cf38bcadde9d3b261e0b6486023421": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3063,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503bd5136ffa144d5464a103ca98d81d905",
+          "Ref": "RestApiDeployment180EC50356cf38bcadde9d3b261e0b6486023421",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3382,7 +3382,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=X-GU-GeoIP-Country-Code&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header.get('X-GU-GeoIP-Country-Code'))",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"X-GU-GeoIP-Country-Code\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"{$request.header.X-GU-GeoIP-Country-Code}\\"}}"",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -47,32 +47,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
     },
-    "apiEndpoint9349E63C": {
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            "https://",
-            {
-              "Ref": "apiC8550315",
-            },
-            ".execute-api.",
-            {
-              "Ref": "AWS::Region",
-            },
-            ".",
-            {
-              "Ref": "AWS::URLSuffix",
-            },
-            "/",
-            {
-              "Ref": "apiDeploymentStageprod896C8101",
-            },
-            "/",
-          ],
-        ],
-      },
-    },
   },
   "Parameters": {
     "DistributionBucketName": {
@@ -432,18 +406,13 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503c1c6a4dfeb8ac35ff8cef92727876ad9": {
+    "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
-        "RestApicreateoneoffOPTIONS1F89A992",
-        "RestApicreateoneoffPOST41A64A32",
-        "RestApicreateoneoff2D1FCD3C",
         "RestApicreateOPTIONSC3837E5E",
-        "RestApicreaterecurringOPTIONSFBFDACD1",
-        "RestApicreaterecurringPOSTC2005445",
-        "RestApicreaterecurringA327119C",
+        "RestApicreatePOST89063740",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -464,7 +433,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503c1c6a4dfeb8ac35ff8cef92727876ad9",
+          "Ref": "RestApiDeployment180EC503801c22eb56fec5ec4109339c7fd2ed27",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -759,64 +728,33 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreateoneoff2D1FCD3C": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApicreate68AA2AF0",
-        },
-        "PathPart": "one-off",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApicreateoneoffOPTIONS1F89A992": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": {
-          "Ref": "RestApicreateoneoff2D1FCD3C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreateoneoffPOST41A64A32": {
+    "RestApicreatePOST89063740": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
         "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayToSqsRole590217A3",
+              "Arn",
+            ],
+          },
           "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
+          "IntegrationResponses": [
+            {
+              "ResponseTemplates": {
+                "application/json": "{"done": true}",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
+          },
+          "RequestTemplates": {
+            "application/json": "Action=SendMessage&MessageBody=$input.body",
+          },
+          "Type": "AWS",
           "Uri": {
             "Fn::Join": [
               "",
@@ -829,267 +767,28 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::Region",
                 },
-                ":lambda:path/2015-03-31/functions/",
+                ":sqs:path/",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                "/",
                 {
                   "Fn::GetAtt": [
-                    "createreminderssignupB956888C",
-                    "Arn",
+                    "supportremindersQueue01C5AB8D",
+                    "QueueName",
                   ],
                 },
-                "/invocations",
               ],
             ],
           },
-        },
-        "ResourceId": {
-          "Ref": "RestApicreateoneoff2D1FCD3C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreateoneoffPOSTApiPermissionSupportRemindersCODERestApi2446198FPOSTcreateoneoff673C3AFA": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/POST/create/one-off",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreateoneoffPOSTApiPermissionTestSupportRemindersCODERestApi2446198FPOSTcreateoneoff90DF1AAD": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/POST/create/one-off",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreaterecurringA327119C": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApicreate68AA2AF0",
-        },
-        "PathPart": "recurring",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApicreaterecurringOPTIONSFBFDACD1": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
         },
         "MethodResponses": [
           {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
+            "StatusCode": "200",
           },
         ],
         "ResourceId": {
-          "Ref": "RestApicreaterecurringA327119C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreaterecurringPOSTApiPermissionSupportRemindersCODERestApi2446198FPOSTcreaterecurringA978DFB3": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/POST/create/recurring",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreaterecurringPOSTApiPermissionTestSupportRemindersCODERestApi2446198FPOSTcreaterecurringE21E016C": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/POST/create/recurring",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreaterecurringPOSTC2005445": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "POST",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "createreminderssignupB956888C",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Ref": "RestApicreaterecurringA327119C",
+          "Ref": "RestApicreate68AA2AF0",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -1464,213 +1163,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "apiAccount57E28B43": {
-      "DeletionPolicy": "Retain",
-      "DependsOn": [
-        "apiC8550315",
-      ],
-      "Properties": {
-        "CloudWatchRoleArn": {
-          "Fn::GetAtt": [
-            "apiCloudWatchRoleAC81D93E",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "apiC8550315": {
-      "Properties": {
-        "Name": "api",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-reminders",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::RestApi",
-    },
-    "apiCloudWatchRoleAC81D93E": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "apigateway.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-reminders",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "apiDeployment149F129446765f02adb599bbbfd06ebca9169f38": {
-      "DependsOn": [
-        "apiPOST36368FF5",
-      ],
-      "Properties": {
-        "Description": "Automatically created by the RestApi construct",
-        "RestApiId": {
-          "Ref": "apiC8550315",
-        },
-      },
-      "Type": "AWS::ApiGateway::Deployment",
-    },
-    "apiDeploymentStageprod896C8101": {
-      "DependsOn": [
-        "apiAccount57E28B43",
-      ],
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "apiDeployment149F129446765f02adb599bbbfd06ebca9169f38",
-        },
-        "RestApiId": {
-          "Ref": "apiC8550315",
-        },
-        "StageName": "prod",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-reminders",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::Stage",
-    },
-    "apiPOST36368FF5": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "POST",
-        "Integration": {
-          "Credentials": {
-            "Fn::GetAtt": [
-              "ApiGatewayToSqsRole590217A3",
-              "Arn",
-            ],
-          },
-          "IntegrationHttpMethod": "POST",
-          "IntegrationResponses": [
-            {
-              "ResponseTemplates": {
-                "application/json": "{"done": true}",
-              },
-              "StatusCode": "200",
-            },
-          ],
-          "RequestParameters": {
-            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
-          },
-          "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body",
-          },
-          "Type": "AWS",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":sqs:path/",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                "/",
-                {
-                  "Fn::GetAtt": [
-                    "supportremindersQueue01C5AB8D",
-                    "QueueName",
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "MethodResponses": [
-          {
-            "StatusCode": "200",
-          },
-        ],
-        "ResourceId": {
-          "Fn::GetAtt": [
-            "apiC8550315",
-            "RootResourceId",
-          ],
-        },
-        "RestApiId": {
-          "Ref": "apiC8550315",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
     },
     "cancelremindersF4DAF18B": {
       "DependsOn": [
@@ -3391,32 +2883,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
     },
-    "apiEndpoint9349E63C": {
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            "https://",
-            {
-              "Ref": "apiC8550315",
-            },
-            ".execute-api.",
-            {
-              "Ref": "AWS::Region",
-            },
-            ".",
-            {
-              "Ref": "AWS::URLSuffix",
-            },
-            "/",
-            {
-              "Ref": "apiDeploymentStageprod896C8101",
-            },
-            "/",
-          ],
-        ],
-      },
-    },
   },
   "Parameters": {
     "DistributionBucketName": {
@@ -3776,18 +3242,13 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5036c6d30ab953d426d0de7e72d49f91562": {
+    "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
-        "RestApicreateoneoffOPTIONS1F89A992",
-        "RestApicreateoneoffPOST41A64A32",
-        "RestApicreateoneoff2D1FCD3C",
         "RestApicreateOPTIONSC3837E5E",
-        "RestApicreaterecurringOPTIONSFBFDACD1",
-        "RestApicreaterecurringPOSTC2005445",
-        "RestApicreaterecurringA327119C",
+        "RestApicreatePOST89063740",
         "RestApicreate68AA2AF0",
         "RestApiOPTIONS6AA64D2D",
         "RestApireactivateOPTIONS263B776D",
@@ -3808,7 +3269,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5036c6d30ab953d426d0de7e72d49f91562",
+          "Ref": "RestApiDeployment180EC503b73f118319c8bf666fcc1a86b9725266",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -4103,64 +3564,33 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "RestApicreateoneoff2D1FCD3C": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApicreate68AA2AF0",
-        },
-        "PathPart": "one-off",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApicreateoneoffOPTIONS1F89A992": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
-          },
-        ],
-        "ResourceId": {
-          "Ref": "RestApicreateoneoff2D1FCD3C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreateoneoffPOST41A64A32": {
+    "RestApicreatePOST89063740": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
         "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayToSqsRole590217A3",
+              "Arn",
+            ],
+          },
           "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
+          "IntegrationResponses": [
+            {
+              "ResponseTemplates": {
+                "application/json": "{"done": true}",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
+          },
+          "RequestTemplates": {
+            "application/json": "Action=SendMessage&MessageBody=$input.body",
+          },
+          "Type": "AWS",
           "Uri": {
             "Fn::Join": [
               "",
@@ -4173,267 +3603,28 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
                 {
                   "Ref": "AWS::Region",
                 },
-                ":lambda:path/2015-03-31/functions/",
+                ":sqs:path/",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                "/",
                 {
                   "Fn::GetAtt": [
-                    "createreminderssignupB956888C",
-                    "Arn",
+                    "supportremindersQueue01C5AB8D",
+                    "QueueName",
                   ],
                 },
-                "/invocations",
               ],
             ],
           },
-        },
-        "ResourceId": {
-          "Ref": "RestApicreateoneoff2D1FCD3C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreateoneoffPOSTApiPermissionSupportRemindersPRODRestApi318F04F5POSTcreateoneoffCB9C5A56": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/POST/create/one-off",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreateoneoffPOSTApiPermissionTestSupportRemindersPRODRestApi318F04F5POSTcreateoneoff02BE2CEA": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/POST/create/one-off",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreaterecurringA327119C": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "RestApicreate68AA2AF0",
-        },
-        "PathPart": "recurring",
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "RestApicreaterecurringOPTIONSFBFDACD1": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "OPTIONS",
-        "Integration": {
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
-                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-              },
-              "StatusCode": "204",
-            },
-          ],
-          "RequestTemplates": {
-            "application/json": "{ statusCode: 200 }",
-          },
-          "Type": "MOCK",
         },
         "MethodResponses": [
           {
-            "ResponseParameters": {
-              "method.response.header.Access-Control-Allow-Headers": true,
-              "method.response.header.Access-Control-Allow-Methods": true,
-              "method.response.header.Access-Control-Allow-Origin": true,
-            },
-            "StatusCode": "204",
+            "StatusCode": "200",
           },
         ],
         "ResourceId": {
-          "Ref": "RestApicreaterecurringA327119C",
-        },
-        "RestApiId": {
-          "Ref": "RestApi0C43BF4B",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "RestApicreaterecurringPOSTApiPermissionSupportRemindersPRODRestApi318F04F5POSTcreaterecurringF86752F5": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/",
-              {
-                "Ref": "RestApiDeploymentStageprod3855DE66",
-              },
-              "/POST/create/recurring",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreaterecurringPOSTApiPermissionTestSupportRemindersPRODRestApi318F04F5POSTcreaterecurring6220A329": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "createreminderssignupB956888C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "RestApi0C43BF4B",
-              },
-              "/test-invoke-stage/POST/create/recurring",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "RestApicreaterecurringPOSTC2005445": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "POST",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "createreminderssignupB956888C",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Ref": "RestApicreaterecurringA327119C",
+          "Ref": "RestApicreate68AA2AF0",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -4808,213 +3999,6 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "apiAccount57E28B43": {
-      "DeletionPolicy": "Retain",
-      "DependsOn": [
-        "apiC8550315",
-      ],
-      "Properties": {
-        "CloudWatchRoleArn": {
-          "Fn::GetAtt": [
-            "apiCloudWatchRoleAC81D93E",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "apiC8550315": {
-      "Properties": {
-        "Name": "api",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-reminders",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::RestApi",
-    },
-    "apiCloudWatchRoleAC81D93E": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "apigateway.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-reminders",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "apiDeployment149F1294461bea2efd612aad2761d2d18c877942": {
-      "DependsOn": [
-        "apiPOST36368FF5",
-      ],
-      "Properties": {
-        "Description": "Automatically created by the RestApi construct",
-        "RestApiId": {
-          "Ref": "apiC8550315",
-        },
-      },
-      "Type": "AWS::ApiGateway::Deployment",
-    },
-    "apiDeploymentStageprod896C8101": {
-      "DependsOn": [
-        "apiAccount57E28B43",
-      ],
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "apiDeployment149F1294461bea2efd612aad2761d2d18c877942",
-        },
-        "RestApiId": {
-          "Ref": "apiC8550315",
-        },
-        "StageName": "prod",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-reminders",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::Stage",
-    },
-    "apiPOST36368FF5": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "POST",
-        "Integration": {
-          "Credentials": {
-            "Fn::GetAtt": [
-              "ApiGatewayToSqsRole590217A3",
-              "Arn",
-            ],
-          },
-          "IntegrationHttpMethod": "POST",
-          "IntegrationResponses": [
-            {
-              "ResponseTemplates": {
-                "application/json": "{"done": true}",
-              },
-              "StatusCode": "200",
-            },
-          ],
-          "RequestParameters": {
-            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
-          },
-          "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body",
-          },
-          "Type": "AWS",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":sqs:path/",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                "/",
-                {
-                  "Fn::GetAtt": [
-                    "supportremindersQueue01C5AB8D",
-                    "QueueName",
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "MethodResponses": [
-          {
-            "StatusCode": "200",
-          },
-        ],
-        "ResourceId": {
-          "Fn::GetAtt": [
-            "apiC8550315",
-            "RootResourceId",
-          ],
-        },
-        "RestApiId": {
-          "Ref": "apiC8550315",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
     },
     "cancelremindersF4DAF18B": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5038818785ffe56af03055de428c5fa4793": {
+    "RestApiDeployment180EC5031f73e9e0881546891a8a5fa8a2a9fff2": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -359,7 +359,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5038818785ffe56af03055de428c5fa4793",
+          "Ref": "RestApiDeployment180EC5031f73e9e0881546891a8a5fa8a2a9fff2",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -678,7 +678,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=Headers&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header)",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=X-GU-GeoIP-Country-Code&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header.get('X-GU-GeoIP-Country-Code'))",
           },
           "Type": "AWS",
           "Uri": {
@@ -3036,7 +3036,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50335deeadc51cca2b968b76e3f8bf25bcf": {
+    "RestApiDeployment180EC503bd5136ffa144d5464a103ca98d81d905": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3063,7 +3063,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50335deeadc51cca2b968b76e3f8bf25bcf",
+          "Ref": "RestApiDeployment180EC503bd5136ffa144d5464a103ca98d81d905",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3382,7 +3382,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=Headers&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header)",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=X-GU-GeoIP-Country-Code&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header.get('X-GU-GeoIP-Country-Code'))",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -11,7 +11,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
-      "GuApiGateway5xxPercentageAlarm",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
       "GuScheduledLambda",
@@ -102,79 +101,6 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Threshold": 8,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ApiGatewayHigh5xxPercentageAlarmSupportreminders2F3286A8": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "support-reminders exceeded 1% error rate",
-        "AlarmName": "High 5XX error % from support-reminders (ApiGateway) in CODE",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": "% of 5XX responses served for support-reminders",
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "ApiName",
-                    "Value": "support-CODE-support-reminders",
-                  },
-                ],
-                "MetricName": "5XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "ApiName",
-                    "Value": "support-CODE-support-reminders",
-                  },
-                ],
-                "MetricName": "Count",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "SampleCount",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -332,7 +332,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503ddd14ce8239bbacaf6192796abf8eb29": {
+    "RestApiDeployment180EC5039c0207ecfdffb9711e2545cf3e18486f": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -364,7 +364,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503ddd14ce8239bbacaf6192796abf8eb29",
+          "Ref": "RestApiDeployment180EC5039c0207ecfdffb9711e2545cf3e18486f",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -734,7 +734,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=$context.path",
           },
           "Type": "AWS",
           "Uri": {
@@ -853,7 +853,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=$context.path",
           },
           "Type": "AWS",
           "Uri": {
@@ -3211,7 +3211,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503425c8ffd6fd88e79f3cc34e8f8338674": {
+    "RestApiDeployment180EC50385c482c5a885cdec79014443bb465ffd": {
       "DependsOn": [
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
@@ -3243,7 +3243,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503425c8ffd6fd88e79f3cc34e8f8338674",
+          "Ref": "RestApiDeployment180EC50385c482c5a885cdec79014443bb465ffd",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3613,7 +3613,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=$context.path",
           },
           "Type": "AWS",
           "Uri": {
@@ -3732,7 +3732,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'",
           },
           "RequestTemplates": {
-            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)",
+            "application/json": "Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params('X-GU-GeoIP-Country-Code')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=$context.path",
           },
           "Type": "AWS",
           "Uri": {

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params(\'X-GU-GeoIP-Country-Code\')',
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params(\'X-GU-GeoIP-Country-Code\')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)',
 				},
 				integrationResponses: [
 					{
@@ -176,7 +176,15 @@ export class SupportReminders extends GuStack {
 
 
 		// post method
-		supportRemindersApi.api.root.resourceForPath('/create').addMethod('POST', sendMessageIntegration, {
+		supportRemindersApi.api.root.resourceForPath('/create/one-off').addMethod('POST', sendMessageIntegration, {
+			methodResponses: [
+				{
+					statusCode: '200',
+				},
+			]
+		});
+		// post method
+		supportRemindersApi.api.root.resourceForPath('/create/recurring').addMethod('POST', sendMessageIntegration, {
 			methodResponses: [
 				{
 					statusCode: '200',

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=Headers&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header)'
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=X-GU-GeoIP-Country-Code&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header.get(\'X-GU-GeoIP-Country-Code\'))'
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"X-GU-GeoIP-Country-Code\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"{$request.header.X-GU-GeoIP-Country-Code}\\"}}"',
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes="{"X-GU-GeoIP-Country-Code":{"DataType":"String","StringValue":"{$request.header.X-GU-GeoIP-Country-Code}"}}"',
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -176,7 +176,7 @@ export class SupportReminders extends GuStack {
 
 
 		// post method
-		supportRemindersApi.api.root.resourceForPath('/create/one-').addMethod('POST', sendMessageIntegration, {
+		supportRemindersApi.api.root.resourceForPath('/create').addMethod('POST', sendMessageIntegration, {
 			methodResponses: [
 				{
 					statusCode: '200',

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"Signature\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"${request.header.signature}\\"}}"',
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes=$input.header',
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params(\'X-GU-GeoIP-Country-Code\')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=‘$context.path)',
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params(\'X-GU-GeoIP-Country-Code\')&MessageAttribute.2.Name=EventPath&MessageAttribute.2.Value.DataType=String&MessageAttribute.2.Value.StringValue=$context.path',
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body',
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"Signature\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"${request.header.signature}\\"}}"',
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -144,7 +144,7 @@ export class SupportReminders extends GuStack {
 				allowMethods: Cors.ALL_METHODS,
 				allowHeaders: ["Content-Type"],
 			},
-			monitoringConfiguration: {
+			monitoringConfiguration: this.stage === 'CODE' ? { noMonitoring: true } : {
 				snsTopicName: alarmsTopic,
 				http5xxAlarm: {
 					tolerated5xxPercentage: 1,

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -156,16 +156,6 @@ export class SupportReminders extends GuStack {
 					httpMethod: "POST",
 					lambda: reactivateRecurringReminderLambda,
 				},
-				// {
-				// 	path: "/create/recurring",
-				// 	httpMethod: "POST",
-				// 	lambda: createRemindersSignupLambda,
-				// },
-				// {
-				// 	path: "/create/one-off",
-				// 	httpMethod: "POST",
-				// 	lambda: createRemindersSignupLambda,
-				// },
 				{
 					path: "/cancel",
 					httpMethod: "POST",
@@ -175,7 +165,7 @@ export class SupportReminders extends GuStack {
 		})
 
 
-		// post method
+		// post method to /create
 		supportRemindersApi.api.root.resourceForPath('/create/one-off').addMethod('POST', sendMessageIntegration, {
 			methodResponses: [
 				{
@@ -183,7 +173,6 @@ export class SupportReminders extends GuStack {
 				},
 			]
 		});
-		// post method
 		supportRemindersApi.api.root.resourceForPath('/create/recurring').addMethod('POST', sendMessageIntegration, {
 			methodResponses: [
 				{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes=$input.header',
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=Headers&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header)'
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes="{"X-GU-GeoIP-Country-Code":{"DataType":"String","StringValue":"{$request.header.X-GU-GeoIP-Country-Code}"}}"',
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttribute.1.Name=X-GU-GeoIP-Country-Code&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=$input.params(\'X-GU-GeoIP-Country-Code\')',
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -82,7 +82,6 @@ export class SupportReminders extends GuStack {
 			vpcSubnets,
 			securityGroups,
 			environment,
-			events,
 		};
 
 		const apiRole = new Role(this, 'ApiGatewayToSqsRole', {
@@ -121,6 +120,7 @@ export class SupportReminders extends GuStack {
 			handler: "create-reminder-signup/lambda/lambda.handler",
 			functionName: `support-reminders-create-reminder-signup-${this.stage}`,
 			...sharedLambdaProps,
+			events,
 		});
 
 		const reactivateRecurringReminderLambda = new GuLambdaFunction(this, "reactivate-recurring-reminder", {
@@ -176,7 +176,7 @@ export class SupportReminders extends GuStack {
 
 
 		// post method
-		supportRemindersApi.api.root.resourceForPath('/create/').addMethod('POST', sendMessageIntegration, {
+		supportRemindersApi.api.root.resourceForPath('/create/one-').addMethod('POST', sendMessageIntegration, {
 			methodResponses: [
 				{
 					statusCode: '200',

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -102,7 +102,7 @@ export class SupportReminders extends GuStack {
 					'integration.request.header.Content-Type': `'application/x-www-form-urlencoded'`,
 				},
 				requestTemplates: {
-					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes.entry.1.Name=X-GU-GeoIP-Country-Code&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=$util.urlEncode($input.params().header.get(\'X-GU-GeoIP-Country-Code\'))'
+					'application/json': 'Action=SendMessage&MessageBody=$input.body&MessageAttributes="{\\"X-GU-GeoIP-Country-Code\\":{\\"DataType\\":\\"String\\",\\"StringValue\\":\\"{$request.header.X-GU-GeoIP-Country-Code}\\"}}"',
 				},
 				integrationResponses: [
 					{

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -6,7 +6,7 @@ import {GuVpc} from "@guardian/cdk/lib/constructs/ec2";
 import {GuLambdaFunction} from "@guardian/cdk/lib/constructs/lambda";
 import type {App} from "aws-cdk-lib";
 import {Duration} from "aws-cdk-lib";
-import { AwsIntegration, CfnBasePathMapping, CfnDomainName, Cors, RestApi } from "aws-cdk-lib/aws-apigateway";
+import { AwsIntegration, CfnBasePathMapping, CfnDomainName, Cors  } from "aws-cdk-lib/aws-apigateway";
 import {ComparisonOperator, Metric} from "aws-cdk-lib/aws-cloudwatch";
 import {SecurityGroup} from "aws-cdk-lib/aws-ec2";
 import {Schedule} from "aws-cdk-lib/aws-events";
@@ -116,18 +116,6 @@ export class SupportReminders extends GuStack {
 			},
 		});
 
-		// Rest Api
-		const api = new RestApi(this, 'api', {});
-
-		// post method
-		api.root.addMethod('POST', sendMessageIntegration, {
-			methodResponses: [
-				{
-					statusCode: '200',
-				},
-			]
-		});
-
 		// ---- API-triggered lambda functions ---- //
 		const createRemindersSignupLambda = new GuLambdaFunction(this, "create-reminders-signup", {
 			handler: "create-reminder-signup/lambda/lambda.handler",
@@ -168,16 +156,16 @@ export class SupportReminders extends GuStack {
 					httpMethod: "POST",
 					lambda: reactivateRecurringReminderLambda,
 				},
-				{
-					path: "/create/recurring",
-					httpMethod: "POST",
-					lambda: createRemindersSignupLambda,
-				},
-				{
-					path: "/create/one-off",
-					httpMethod: "POST",
-					lambda: createRemindersSignupLambda,
-				},
+				// {
+				// 	path: "/create/recurring",
+				// 	httpMethod: "POST",
+				// 	lambda: createRemindersSignupLambda,
+				// },
+				// {
+				// 	path: "/create/one-off",
+				// 	httpMethod: "POST",
+				// 	lambda: createRemindersSignupLambda,
+				// },
 				{
 					path: "/cancel",
 					httpMethod: "POST",
@@ -185,6 +173,17 @@ export class SupportReminders extends GuStack {
 				},
 			],
 		})
+
+
+		// post method
+		supportRemindersApi.api.root.resourceForPath('/create/').addMethod('POST', sendMessageIntegration, {
+			methodResponses: [
+				{
+					statusCode: '200',
+				},
+			]
+		});
+
 
 
 		// ---- Scheduled lambda functions ---- //

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -42,13 +42,22 @@ const identityAccessTokenPromise: Promise<string> = getParamFromSSM(
 export const run = async (event: SQSEvent): Promise<void> => {
 	console.log('received event: ', event);
 
+	console.log('received header: ', event.Records[0].messageAttributes);
+	console.log(
+		'received header1: ',
+		event.Records[0].messageAttributes['EventPath'],
+	);
+	console.log(
+		'received header2: ',
+		event.Records[0].messageAttributes['EventPath'].stringValue,
+	);
+
 	const country =
 		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code']
 			.stringValue;
 
 	const eventPath =
-		event.Records[0].messageAttributes['EventPath']
-			.stringValue;
+		event.Records[0].messageAttributes['EventPath'].stringValue;
 
 	const signupRequest: unknown = {
 		country,

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -43,7 +43,11 @@ export const run = async (event: SQSEvent): Promise<void> => {
 	console.log('received event: ', event);
 
 	const country = event.headers['X-GU-GeoIP-Country-Code'];
-	const signupRequest: unknown = { country, ...JSON.parse(event.body) };
+
+	const signupRequest: unknown = {
+		country,
+		...JSON.parse(event.Records[0].body),
+	};
 
 	let result;
 	if (event.path === '/create/one-off') {

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -42,31 +42,25 @@ const identityAccessTokenPromise: Promise<string> = getParamFromSSM(
 export const run = async (event: SQSEvent): Promise<void> => {
 	console.log('received event: ', event);
 
-	console.log('received header: ', event.Records[0].messageAttributes);
-	console.log(
-		'received header1: ',
-		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code'],
-	);
-	console.log(
-		'received header2: ',
-		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code']
-			.stringValue,
-	);
-
 	const country =
 		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code']
 			.stringValue;
-	// const country = event.headers['X-GU-GeoIP-Country-Code'];
+
+	const eventPath =
+		event.Records[0].messageAttributes['EventPath']
+			.stringValue;
 
 	const signupRequest: unknown = {
 		country,
 		...JSON.parse(event.Records[0].body),
 	};
 
+	console.log('signupRequest: ', signupRequest);
+
 	let result;
-	if (event.path === '/create/one-off') {
+	if (eventPath === '/create/one-off') {
 		result = await runOneOff(signupRequest);
-	} else if (event.path === '/create/recurring') {
+	} else if (eventPath === '/create/recurring') {
 		result = await runRecurring(signupRequest);
 	}
 

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -42,16 +42,6 @@ const identityAccessTokenPromise: Promise<string> = getParamFromSSM(
 export const run = async (event: SQSEvent): Promise<void> => {
 	console.log('received event: ', event);
 
-	console.log('received header: ', event.Records[0].messageAttributes);
-	console.log(
-		'received header1: ',
-		event.Records[0].messageAttributes['EventPath'],
-	);
-	console.log(
-		'received header2: ',
-		event.Records[0].messageAttributes['EventPath'].stringValue,
-	);
-
 	const country =
 		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code']
 			.stringValue;
@@ -64,17 +54,12 @@ export const run = async (event: SQSEvent): Promise<void> => {
 		...JSON.parse(event.Records[0].body),
 	};
 
-	console.log('signupRequest: ', signupRequest);
-
 	let result;
 	if (eventPath === '/create/one-off') {
 		result = await runOneOff(signupRequest);
 	} else if (eventPath === '/create/recurring') {
 		result = await runRecurring(signupRequest);
 	}
-
-	console.log('Result', result);
-	// return { headers, statusCode: 404, body: 'Not found' };
 };
 
 export const runOneOff = async (

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -42,7 +42,10 @@ const identityAccessTokenPromise: Promise<string> = getParamFromSSM(
 export const run = async (event: SQSEvent): Promise<void> => {
 	console.log('received event: ', event);
 
-	const country = event.headers['X-GU-GeoIP-Country-Code'];
+	const country =
+		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code']
+			.stringValue;
+	// const country = event.headers['X-GU-GeoIP-Country-Code'];
 
 	const signupRequest: unknown = {
 		country,

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -42,6 +42,17 @@ const identityAccessTokenPromise: Promise<string> = getParamFromSSM(
 export const run = async (event: SQSEvent): Promise<void> => {
 	console.log('received event: ', event);
 
+	console.log('received header: ', event.Records[0].messageAttributes);
+	console.log(
+		'received header1: ',
+		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code'],
+	);
+	console.log(
+		'received header2: ',
+		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code']
+			.stringValue,
+	);
+
 	const country =
 		event.Records[0].messageAttributes['X-GU-GeoIP-Country-Code']
 			.stringValue;


### PR DESCRIPTION
## What does this change?

This PR is to add a queue between the API Gateway and the lambda for the support-reminders

Currently when a user creates a reminder signup, the request goes to an API gateway which integrates directly with a lambda.
Sometimes this lambda fails because IDAPI has a temporary issue. The user will see an error message on the page.
We could instead always return a 200 to the client, and use an SQS queue to retry when there are errors.

[Trello card ](https://trello.com/c/vYCQrutZ/554-reminder-signup-retries)
Note:

Mapping templates  for the ntegration request  is as below
<img width="1189" alt="image" src="https://github.com/user-attachments/assets/e050e61e-c759-4288-baa7-f3bbf314fcfa">

Here we are adding the  X-GU-GeoIP-Country-Code in the request header as the first element  and the path as the second element  in the MessageAttribute Object.

##Tested in CODE

##For One-off 
<img width="1189" alt="image" src="https://github.com/user-attachments/assets/bb874536-9a3b-4569-9341-266950dffd17">

<img width="1419" alt="image" src="https://github.com/user-attachments/assets/89249879-ace7-4301-97d3-952f05f405fd">

##For recurring 
<img width="1189" alt="image" src="https://github.com/user-attachments/assets/76ee14ff-ebb4-44be-97cb-1ce0056f23be">

<img width="1489" alt="image" src="https://github.com/user-attachments/assets/105f7328-4cdb-4a89-af3b-2a5a0a279884">
