### PR TITLE
Validate country code header

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -350,9 +350,10 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50394e319ffe9f5f50f772c279a73b63764": {
+    "RestApiDeployment180EC503a345def70b385514941e7a699c9d376f": {
       "DependsOn": [
         "oneoffvalidator0C4177E4",
+        "recurringvalidatorA3C040BF",
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
@@ -383,7 +384,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50394e319ffe9f5f50f772c279a73b63764",
+          "Ref": "RestApiDeployment180EC503a345def70b385514941e7a699c9d376f",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -918,6 +919,12 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "StatusCode": "200",
           },
         ],
+        "RequestParameters": {
+          "method.request.header.X-GU-GeoIP-Country-Code": true,
+        },
+        "RequestValidatorId": {
+          "Ref": "recurringvalidatorA3C040BF",
+        },
         "ResourceId": {
           "Ref": "RestApicreaterecurringA327119C",
         },
@@ -2460,6 +2467,15 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "recurringvalidatorA3C040BF": {
+      "Properties": {
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "ValidateRequestParameters": true,
+      },
+      "Type": "AWS::ApiGateway::RequestValidator",
+    },
     "signupexportsDBFAB572": {
       "DependsOn": [
         "signupexportsServiceRoleDefaultPolicy7B14F7DA",
@@ -3338,9 +3354,10 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503a23ae4dcaca1e433b36c59c80393fd9a": {
+    "RestApiDeployment180EC503527c2dadd44b8927ecf4437252adb507": {
       "DependsOn": [
         "oneoffvalidator0C4177E4",
+        "recurringvalidatorA3C040BF",
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
@@ -3371,7 +3388,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503a23ae4dcaca1e433b36c59c80393fd9a",
+          "Ref": "RestApiDeployment180EC503527c2dadd44b8927ecf4437252adb507",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3906,6 +3923,12 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "StatusCode": "200",
           },
         ],
+        "RequestParameters": {
+          "method.request.header.X-GU-GeoIP-Country-Code": true,
+        },
+        "RequestValidatorId": {
+          "Ref": "recurringvalidatorA3C040BF",
+        },
         "ResourceId": {
           "Ref": "RestApicreaterecurringA327119C",
         },
@@ -5447,6 +5470,15 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "recurringvalidatorA3C040BF": {
+      "Properties": {
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "ValidateRequestParameters": true,
+      },
+      "Type": "AWS::ApiGateway::RequestValidator",
     },
     "signupexportsDBFAB572": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -350,8 +350,9 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503fcf0333a4041292d1f2defc7f14d62da": {
+    "RestApiDeployment180EC50375bf4a3a3927649c4d17a8062e486ec2": {
       "DependsOn": [
+        "oneoffvalidator0C4177E4",
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
@@ -382,7 +383,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503fcf0333a4041292d1f2defc7f14d62da",
+          "Ref": "RestApiDeployment180EC50375bf4a3a3927649c4d17a8062e486ec2",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -791,6 +792,12 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
             "StatusCode": "200",
           },
         ],
+        "RequestParameters": {
+          "integration.request.header.X-GU-GeoIP-Country-Code": true,
+        },
+        "RequestValidatorId": {
+          "Ref": "oneoffvalidator0C4177E4",
+        },
         "ResourceId": {
           "Ref": "RestApicreateoneoff2D1FCD3C",
         },
@@ -2211,6 +2218,15 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
+    "oneoffvalidator0C4177E4": {
+      "Properties": {
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "ValidateRequestParameters": true,
+      },
+      "Type": "AWS::ApiGateway::RequestValidator",
+    },
     "reactivaterecurringreminder0045F57B": {
       "DependsOn": [
         "reactivaterecurringreminderServiceRoleDefaultPolicyA6827EC3",
@@ -3322,8 +3338,9 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503aeb5683c0cd969c7e8fc564945b91afc": {
+    "RestApiDeployment180EC503c799b5d183678aecee5a08190a2256b9": {
       "DependsOn": [
+        "oneoffvalidator0C4177E4",
         "RestApicancelOPTIONS8CB256F3",
         "RestApicancelPOST51F94A62",
         "RestApicancel928D6387",
@@ -3354,7 +3371,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503aeb5683c0cd969c7e8fc564945b91afc",
+          "Ref": "RestApiDeployment180EC503c799b5d183678aecee5a08190a2256b9",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3763,6 +3780,12 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
             "StatusCode": "200",
           },
         ],
+        "RequestParameters": {
+          "integration.request.header.X-GU-GeoIP-Country-Code": true,
+        },
+        "RequestValidatorId": {
+          "Ref": "oneoffvalidator0C4177E4",
+        },
         "ResourceId": {
           "Ref": "RestApicreateoneoff2D1FCD3C",
         },
@@ -5182,6 +5205,15 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "oneoffvalidator0C4177E4": {
+      "Properties": {
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "ValidateRequestParameters": true,
+      },
+      "Type": "AWS::ApiGateway::RequestValidator",
     },
     "reactivaterecurringreminder0045F57B": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -350,7 +350,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50375bf4a3a3927649c4d17a8062e486ec2": {
+    "RestApiDeployment180EC50394e319ffe9f5f50f772c279a73b63764": {
       "DependsOn": [
         "oneoffvalidator0C4177E4",
         "RestApicancelOPTIONS8CB256F3",
@@ -383,7 +383,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50375bf4a3a3927649c4d17a8062e486ec2",
+          "Ref": "RestApiDeployment180EC50394e319ffe9f5f50f772c279a73b63764",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -793,7 +793,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
           },
         ],
         "RequestParameters": {
-          "integration.request.header.X-GU-GeoIP-Country-Code": true,
+          "method.request.header.X-GU-GeoIP-Country-Code": true,
         },
         "RequestValidatorId": {
           "Ref": "oneoffvalidator0C4177E4",
@@ -3338,7 +3338,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC503c799b5d183678aecee5a08190a2256b9": {
+    "RestApiDeployment180EC503a23ae4dcaca1e433b36c59c80393fd9a": {
       "DependsOn": [
         "oneoffvalidator0C4177E4",
         "RestApicancelOPTIONS8CB256F3",
@@ -3371,7 +3371,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC503c799b5d183678aecee5a08190a2256b9",
+          "Ref": "RestApiDeployment180EC503a23ae4dcaca1e433b36c59c80393fd9a",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -3781,7 +3781,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
           },
         ],
         "RequestParameters": {
-          "integration.request.header.X-GU-GeoIP-Country-Code": true,
+          "method.request.header.X-GU-GeoIP-Country-Code": true,
         },
         "RequestValidatorId": {
           "Ref": "oneoffvalidator0C4177E4",

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -176,7 +176,7 @@ export class SupportReminders extends GuStack {
 				},
 			],
 			requestParameters: {
-				'integration.request.header.X-GU-GeoIP-Country-Code': true,
+				'method.request.header.X-GU-GeoIP-Country-Code': true,
 			},
 			requestValidator: new RequestValidator(this, 'one-off-validator', {
 				restApi: supportRemindersApi.api,

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -6,7 +6,7 @@ import {GuVpc} from "@guardian/cdk/lib/constructs/ec2";
 import {GuLambdaFunction} from "@guardian/cdk/lib/constructs/lambda";
 import type {App} from "aws-cdk-lib";
 import {Duration} from "aws-cdk-lib";
-import { AwsIntegration, CfnBasePathMapping, CfnDomainName, Cors  } from "aws-cdk-lib/aws-apigateway";
+import {AwsIntegration, CfnBasePathMapping, CfnDomainName, Cors, RequestValidator} from "aws-cdk-lib/aws-apigateway";
 import {ComparisonOperator, Metric} from "aws-cdk-lib/aws-cloudwatch";
 import {SecurityGroup} from "aws-cdk-lib/aws-ec2";
 import {Schedule} from "aws-cdk-lib/aws-events";
@@ -174,7 +174,14 @@ export class SupportReminders extends GuStack {
 				{
 					statusCode: '200',
 				},
-			]
+			],
+			requestParameters: {
+				'integration.request.header.X-GU-GeoIP-Country-Code': true,
+			},
+			requestValidator: new RequestValidator(this, 'one-off-validator', {
+				restApi: supportRemindersApi.api,
+				validateRequestParameters: true
+			})
 		});
 		supportRemindersApi.api.root.resourceForPath('/create/recurring').addMethod('POST', sendMessageIntegration, {
 			methodResponses: [

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -181,14 +181,21 @@ export class SupportReminders extends GuStack {
 			requestValidator: new RequestValidator(this, 'one-off-validator', {
 				restApi: supportRemindersApi.api,
 				validateRequestParameters: true
-			})
+			}),
 		});
 		supportRemindersApi.api.root.resourceForPath('/create/recurring').addMethod('POST', sendMessageIntegration, {
 			methodResponses: [
 				{
 					statusCode: '200',
 				},
-			]
+			],
+			requestParameters: {
+				'method.request.header.X-GU-GeoIP-Country-Code': true,
+			},
+			requestValidator: new RequestValidator(this, 'recurring-validator', {
+				restApi: supportRemindersApi.api,
+				validateRequestParameters: true
+			}),
 		});
 
 


### PR DESCRIPTION
The country code header is expected by the api gateway request template and passed through in the payload to SQS.
However, if a client doesn't supply the header then a 200 is returned and it quietly fails to send the event to SQS.

This change adds validation to the signup endpoints to require the header. If it's missing then a 400 is returned with:
```
{
    "message": "Missing required request parameters: [X-GU-GeoIP-Country-Code]"
}
```

In the aws console this shows in the method request section:
![Screenshot 2024-12-16 at 15 50 48](https://github.com/user-attachments/assets/8457f554-e050-4126-9fd0-bed1734d277b)
