### PR TITLE
Refactor to use SQSBatchResponse

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -6,6 +6,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuVpcParameter",
       "GuSubnetListParameter",
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -2909,6 +2910,68 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
+    "supportremindersalarm1BE4F065": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "A reminder signup event failed and is now on the dead letter queue.",
+        "AlarmName": "support-reminders-CODE: failed event on the dead letter queue",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "deadletterssupportremindersQueue83E67347",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 24,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
   },
 }
 `;
@@ -2919,6 +2982,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
     "gu:cdk:constructs": [
       "GuVpcParameter",
       "GuSubnetListParameter",
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -5913,6 +5977,68 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
+    },
+    "supportremindersalarm1BE4F065": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "A reminder signup event failed and is now on the dead letter queue.",
+        "AlarmName": "support-reminders-PROD: failed event on the dead letter queue",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "deadletterssupportremindersQueue83E67347",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 24,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-reminders",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
   },
 }

--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -1787,6 +1787,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
     },
     "createreminderssignupSqsEventSourceSupportRemindersCODEsupportremindersQueueD5BCDE9BE219E9BA": {
       "Properties": {
+        "BatchSize": 1,
         "EventSourceArn": {
           "Fn::GetAtt": [
             "supportremindersQueue01C5AB8D",
@@ -4791,6 +4792,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
     },
     "createreminderssignupSqsEventSourceSupportRemindersPRODsupportremindersQueue30985D82167501E9": {
       "Properties": {
+        "BatchSize": 1,
         "EventSourceArn": {
           "Fn::GetAtt": [
             "supportremindersQueue01C5AB8D",

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -71,6 +71,7 @@ export class SupportReminders extends GuStack {
 		// SQS to Lambda event source mapping
 		const eventSource = new SqsEventSource(queue, {
 			reportBatchItemFailures: true,
+			batchSize: 1,
 		});
 		const events=[eventSource];
 

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -57,6 +57,20 @@ export class SupportReminders extends GuStack {
 			retentionPeriod: Duration.days(14),
 		});
 
+		new GuAlarm(this, `${app}-alarm`, {
+			app: app,
+			snsTopicName: alarmsTopic,
+			alarmName: `${app}-${this.stage}: failed event on the dead letter queue`,
+			alarmDescription: `A reminder signup event failed and is now on the dead letter queue.`,
+			metric: deadLetterQueue
+				.metric('ApproximateNumberOfMessagesVisible')
+				.with({ statistic: 'Sum', period: Duration.minutes(1) }),
+			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+			threshold: 0,
+			evaluationPeriods: 24,
+			actionsEnabled: this.stage === 'PROD',
+		});
+
 		const queue = new Queue(this, `${app}Queue`, {
 			queueName,
 			visibilityTimeout: Duration.minutes(2),

--- a/src/cancel-reminders/lambda/lambda.ts
+++ b/src/cancel-reminders/lambda/lambda.ts
@@ -1,10 +1,10 @@
-import { APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import * as AWS from 'aws-sdk';
 import * as SSM from 'aws-sdk/clients/ssm';
 import { Pool } from 'pg';
 import { createDatabaseConnectionPool } from '../../lib/db';
-import { getHandler } from '../../lib/handler';
-import { APIGatewayEvent, ValidationErrors } from '../../lib/models';
+import { getApiGatewayHandler } from '../../lib/handler';
+import { ValidationErrors } from '../../lib/models';
 import { getDatabaseParamsFromSSM } from '../../lib/ssm';
 import { cancelPendingSignups } from '../lib/db';
 import { cancellationValidator } from './models';
@@ -23,11 +23,11 @@ const dbConnectionPoolPromise: Promise<Pool> = getDatabaseParamsFromSSM(
 ).then(createDatabaseConnectionPool);
 
 export const run = async (
-	event: APIGatewayEvent,
+	event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> => {
 	console.log('received event: ', event);
 
-	const cancellationRequest: unknown = JSON.parse(event.body);
+	const cancellationRequest: unknown = JSON.parse(event.body ?? '');
 
 	const validationErrors: ValidationErrors = [];
 	if (!cancellationValidator(cancellationRequest, validationErrors)) {
@@ -46,4 +46,4 @@ export const run = async (
 	return { headers, statusCode: 200, body: 'OK' };
 };
 
-export const handler = getHandler(run);
+export const handler = getApiGatewayHandler(run);

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -41,7 +41,7 @@ export const run = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 	// If there is an error, return the messageId to SQS
 	return processRecord(record)
 		.then(() => ({
-			batchItemFailures: [{ itemIdentifier: record.messageId }],
+			batchItemFailures: [],
 		}))
 		.catch((error) => {
 			console.log(error);

--- a/src/lib/handler.ts
+++ b/src/lib/handler.ts
@@ -9,28 +9,30 @@ import {
 	SQSHandler,
 } from 'aws-lambda';
 
-const getHandler =
-	<INPUT, OUTPUT>(run: (event: INPUT) => Promise<OUTPUT>) =>
-	(event: INPUT, context: Context, callback: Callback<OUTPUT>): void => {
-		// setTimeout is necessary because of a bug in the node lambda runtime which can break requests to ssm
-		setTimeout(() => {
-			// If we do not set this then the lambda will wait 10secs before completing.
-			// This is because pg starts a 10sec timer for each new client (see idleTimeoutMillis in https://node-postgres.com/api/pool).
-			// `callbackWaitsForEmptyEventLoop = false` ensures the invocation ends immediately (https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html)
-			context.callbackWaitsForEmptyEventLoop = false;
+const getHandler = <INPUT, OUTPUT>(run: (event: INPUT) => Promise<OUTPUT>) => (
+	event: INPUT,
+	context: Context,
+	callback: Callback<OUTPUT>,
+): void => {
+	// setTimeout is necessary because of a bug in the node lambda runtime which can break requests to ssm
+	setTimeout(() => {
+		// If we do not set this then the lambda will wait 10secs before completing.
+		// This is because pg starts a 10sec timer for each new client (see idleTimeoutMillis in https://node-postgres.com/api/pool).
+		// `callbackWaitsForEmptyEventLoop = false` ensures the invocation ends immediately (https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html)
+		context.callbackWaitsForEmptyEventLoop = false;
 
-			run(event)
-				.then((result) => {
-					console.log('Returning to client:', JSON.stringify(result));
-					callback(null, result);
-				})
-				.catch((err) => {
-					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- any
-					console.log(`Error: ${err}`);
-					callback(err);
-				});
-		});
-	};
+		run(event)
+			.then((result) => {
+				console.log('Returning to client:', JSON.stringify(result));
+				callback(null, result);
+			})
+			.catch((err) => {
+				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- any
+				console.log(`Error: ${err}`);
+				callback(err);
+			});
+	});
+};
 
 export const getApiGatewayHandler = (
 	run: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>,

--- a/src/lib/handler.ts
+++ b/src/lib/handler.ts
@@ -1,33 +1,41 @@
 import {
-	APIGatewayProxyCallback,
+	APIGatewayProxyEvent,
+	APIGatewayProxyHandler,
 	APIGatewayProxyResult,
+	Callback,
 	Context,
+	SQSBatchResponse,
+	SQSEvent,
+	SQSHandler,
 } from 'aws-lambda';
-import { APIGatewayEvent } from './models';
 
-export const getHandler = (
-	run: (event: APIGatewayEvent) => Promise<APIGatewayProxyResult>,
-) => (
-	event: APIGatewayEvent,
-	context: Context,
-	callback: APIGatewayProxyCallback,
-): void => {
-	// setTimeout is necessary because of a bug in the node lambda runtime which can break requests to ssm
-	setTimeout(() => {
-		// If we do not set this then the lambda will wait 10secs before completing.
-		// This is because pg starts a 10sec timer for each new client (see idleTimeoutMillis in https://node-postgres.com/api/pool).
-		// `callbackWaitsForEmptyEventLoop = false` ensures the invocation ends immediately (https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html)
-		context.callbackWaitsForEmptyEventLoop = false;
+const getHandler =
+	<INPUT, OUTPUT>(run: (event: INPUT) => Promise<OUTPUT>) =>
+	(event: INPUT, context: Context, callback: Callback<OUTPUT>): void => {
+		// setTimeout is necessary because of a bug in the node lambda runtime which can break requests to ssm
+		setTimeout(() => {
+			// If we do not set this then the lambda will wait 10secs before completing.
+			// This is because pg starts a 10sec timer for each new client (see idleTimeoutMillis in https://node-postgres.com/api/pool).
+			// `callbackWaitsForEmptyEventLoop = false` ensures the invocation ends immediately (https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html)
+			context.callbackWaitsForEmptyEventLoop = false;
 
-		run(event)
-			.then((result) => {
-				console.log('Returning to client:', JSON.stringify(result));
-				callback(null, result);
-			})
-			.catch((err) => {
-				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- any
-				console.log(`Error: ${err}`);
-				callback(err);
-			});
-	});
-};
+			run(event)
+				.then((result) => {
+					console.log('Returning to client:', JSON.stringify(result));
+					callback(null, result);
+				})
+				.catch((err) => {
+					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- any
+					console.log(`Error: ${err}`);
+					callback(err);
+				});
+		});
+	};
+
+export const getApiGatewayHandler = (
+	run: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>,
+): APIGatewayProxyHandler => getHandler(run);
+
+export const getSQSHandler = (
+	run: (event: SQSEvent) => Promise<SQSBatchResponse>,
+): SQSHandler => getHandler(run);

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,13 +1,8 @@
 import * as IR from 'typecheck.macro/dist/IR';
 
-export interface APIGatewayEvent {
-	headers: Record<string, string | undefined>;
-	path: string;
-	body: string;
-}
-
 export function isValidEmail(email: string): boolean {
-	const re = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
+	const re =
+		/[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 	return re.test(email.toLowerCase());
 }
 


### PR DESCRIPTION
An [earlier PR](https://github.com/guardian/support-reminders/pull/204) introduced an SQS queue between the api gateway and the sign-ups lambda. The intention was to enable retries of failed events.

The sign-ups lambda is however not returning events to the queue in all failure cases.
For example, an invalid payload will cause a failure in the lambda, but the event is not put back on the queue.
This PR refactors it to return an `SQSBatchResponse` containing the failed messageId, to tell SQS that it failed. [Docs](https://docs.aws.amazon.com/lambda/latest/dg/example_serverless_SQS_Lambda_batch_item_failures_section.html)

I also noticed that currently the lambda only uses the first record in the batch, but in cdk we have not configured the batch size to be 1. This means we currently ignore any other records in the batch. For now I've configured the batch size to be 1, though we could update the lambda to handle many records per batch later.

Part of this change is a refactor of the `getHandler` function. Previously this was always used for lambdas that integrate directly with api gateway. However, this is no longer the case as the sign-ups lambda integrates with SQS instead.
The `getHandler` function is now generic and private, and we now have two exported functions:
`getApiGatewayHandler`
`getSQSHandler`

## Testing
Deployed to CODE and sent sign-up requests to the API:
1. with a correct payload, the lambda successfully writes to the DB and returns empty `batchItemFailures`
2. with an incorrect payload, the lambda logs an error and returns the record's ID in the `batchItemFailures`. I then observed the event go back to the queue, and then onto the dead letter queue.

Lambda logs:
![Screenshot 2024-12-17 at 12 15 26](https://github.com/user-attachments/assets/1f2680b0-f6c2-4a56-b4b8-47f6ae67c0e4)

DLQ:
![Screenshot 2024-12-17 at 12 16 40](https://github.com/user-attachments/assets/17f190b7-9605-4791-8bf9-ba65c1a9055a)
