### PR TITLE
Fix email encoding issue

### DIFF
--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -122,8 +122,11 @@ const createSignup = async <T extends BaseSignupRequest>(
 	const token = await identityAccessTokenPromise;
 	const pool = await dbConnectionPoolPromise;
 
+	// The API gateway -> SQS integration encodes + as a space in the email string
+	const email = signupRequest.email.replace(' ', '+');
+
 	const identityResult = await getOrCreateIdentityIdByEmail(
-		signupRequest.email,
+		email,
 		signupRequest.reminderStage,
 		token,
 	);


### PR DESCRIPTION
Currently if a reminder sign-up request has an email address containing a `+` then the request fails.
This is because the API gateway --> SQS integration is encoding `+` as a space. IDAPI then rejects the email address as invalid, because it has a space.

I've not been able to find a way to fix this at the api gateway level. This appears to be the only way to integrate with SQS. Our configuration is here:
https://github.com/guardian/support-reminders/blob/main/cdk/lib/support-reminders.ts#L120

So the fix in this PR is to change the lambda (which reads the events from SQS) to replace any spaces in the email with a `+`.

## Testing
Deployed to CODE, sent a sign-up request to `/create/one-off`:
```
{
    "email": "test+test@guardian.co.uk",
    "reminderPeriod": "2025-01-01",
    "reminderPlatform": "WEB",
    "reminderComponent": "EPIC",
    "reminderStage": "PRE"
}
```
Before the change, this would fail when IDAPI returns a 400.
Now it successfully created an identity account and created the reminder record:
![Screenshot 2024-12-19 at 12 03 45](https://github.com/user-attachments/assets/658eb248-9eed-45df-a7e1-18ed4143d246)
