### PR TITLE
Remove 'failed' from identity log

### DIFF
--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -49,7 +49,7 @@ export const getIdentityIdByEmail = async (
 	if (!response.ok) {
 		return response.text().then((body) => {
 			console.log(
-				`Failed to get identity ID for email ${email}`,
+				`Unable to get identity ID for email ${email}`,
 				response.status,
 				body,
 			);

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -49,7 +49,7 @@ export const getIdentityIdByEmail = async (
 	if (!response.ok) {
 		return response.text().then((body) => {
 			console.log(
-				`Unable to get identity ID for email ${email}`,
+				`Unable to lookup identity ID for email ${email}`,
 				response.status,
 				body,
 			);


### PR DESCRIPTION
Currently in the reminder sign-up lambda logs, we see the following if the email address is new to the guardian:
`INFO	Failed to get identity ID for email [EMAIL ADDRESS] 404 `

It will then go onto create a guest identity account for the user.
The word "Failed" is a bit dramatic and gives the impression something went wrong, so I'm changing it here