### PR TITLE
Replace all when handling + in emails

### DIFF
--- a/src/create-reminder-signup/lambda/models.test.ts
+++ b/src/create-reminder-signup/lambda/models.test.ts
@@ -91,12 +91,12 @@ describe('request validation', () => {
 	it('transforms an email address containing a space', () => {
 		// Identity’s guest creation endpoint errors if the provided email address is more than 100 characters long
 		// See baseSignupRequestSchema definition for details
-		const email = 'test afterplus@theguardian.com';
+		const email = 'test after plus@theguardian.com';
 		const result = oneOffSignupRequestSchema.safeParse({
 			...oneOffSignupRequest,
 			email,
 		});
 		expect(result.success).toBe(true);
-		expect(result.data?.email).toBe('test+afterplus@theguardian.com');
+		expect(result.data?.email).toBe('test+after+plus@theguardian.com');
 	});
 });

--- a/src/create-reminder-signup/lambda/models.ts
+++ b/src/create-reminder-signup/lambda/models.ts
@@ -52,7 +52,7 @@ export const baseSignupRequestSchema = z.object({
 		// Identity’s guest creation endpoint errors if the provided email address is more than 100 characters long
 		.max(100)
 		// The API gateway -> SQS integration encodes + as a space in the email string
-		.transform((email) => email.replace(' ', '+'))
+		.transform((email) => email.replace(/ /g, '+'))
 		.pipe(z.string().email()),
 	country: z.string().optional(),
 	reminderCreatedAt: z.string().datetime().optional(),

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -12,7 +12,7 @@ export const idapiBaseUrl = isProd()
 	: 'https://idapi.code.dev-theguardian.com';
 
 const encodeEmail = (email: string): string =>
-	encodeURI(email).replace('+', '%2B');
+	encodeURI(email).replace(/\+/g, '%2B');
 
 export interface IdentitySuccess {
 	name: 'success';


### PR DESCRIPTION
[flagged by a code scanning alert](https://github.com/guardian/support-reminders/security/code-scanning/1)
We have special handling for plus signs in email addresses:
1. when receiving a request via api gateway, it replaces `+` with a space
2. when sending to identity api, which needs `+` to be encoded

In both cases we're doing a string `replace` call that only replaces the first instance.
This PR changes it to a regex with the global flag, to indicate that all instances should be replaced.

Tested in CODE by creating reminders for email addresses with `+` in