### PR TITLE
Alter validation to remove problems we can't fix, use Okta email validation

### DIFF
--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -100,6 +100,7 @@ const runRecurring = async (signupRequest: unknown): Promise<void> => {
 
 /**
  * There are some validation errors that currently end up on the DLQ which we can't actually fix.  This ignores those.
+ * https://github.com/guardian/identity/blob/0580155e9eac0fe52ef4772fa1ae72d91155f258/identity-model/src/main/scala/com/gu/identity/model/Errors.scala
  * @param identityResult
  * @returns Promise<void>
  */

--- a/src/create-reminder-signup/lambda/lambda.ts
+++ b/src/create-reminder-signup/lambda/lambda.ts
@@ -115,7 +115,8 @@ const ignoreSomeValidationErrors = async (
 	// email addresses that fail validation should not be passed to the DQL
 	const ignoreInvalidEmailAddress =
 		identityResult.errorMessage?.errors.filter((e) => {
-			e.message === 'Invalid emailAddress';
+			e.description === 'Invalid email format' ||
+				e.message == 'Invalid emailAddress:';
 		});
 
 	if (!(ignoreBlockedProvider || ignoreInvalidEmailAddress)) {

--- a/src/create-reminder-signup/lambda/models.test.ts
+++ b/src/create-reminder-signup/lambda/models.test.ts
@@ -35,15 +35,6 @@ describe('request validation', () => {
 		expect(result.success).toBe(true);
 	});
 
-	it('rejects a OneOffSignupRequest with invalid email', () => {
-		const result = oneOffSignupRequestSchema.safeParse({
-			...oneOffSignupRequest,
-			email: 'notavalidemail',
-		});
-		expect(result.success).toBe(false);
-		expect(result.error?.errors[0].message).toEqual('Invalid email');
-	});
-
 	it('rejects a OneOffSignupRequest with a really long email', () => {
 		let email = '';
 		for (let i = 0; i < 100; i++) {

--- a/src/create-reminder-signup/lambda/models.ts
+++ b/src/create-reminder-signup/lambda/models.ts
@@ -52,8 +52,8 @@ export const baseSignupRequestSchema = z.object({
 		// Identity’s guest creation endpoint errors if the provided email address is more than 100 characters long
 		.max(100)
 		// The API gateway -> SQS integration encodes + as a space in the email string
-		.transform((email) => email.replace(/ /g, '+'))
-		.pipe(z.string().email()),
+		.transform((email) => email.replace(/ /g, '+')),
+	// .pipe(z.string().email()), // TODO: remove this validation in favour of IDAPI's validation
 	country: z.string().optional(),
 	reminderCreatedAt: z.string().datetime().optional(),
 	reminderPlatform: reminderPlatformSchema,

--- a/src/create-reminder-signup/lambda/models.ts
+++ b/src/create-reminder-signup/lambda/models.ts
@@ -53,7 +53,6 @@ export const baseSignupRequestSchema = z.object({
 		.max(100)
 		// The API gateway -> SQS integration encodes + as a space in the email string
 		.transform((email) => email.replace(/ /g, '+')),
-	// .pipe(z.string().email()), // TODO: remove this validation in favour of IDAPI's validation
 	country: z.string().optional(),
 	reminderCreatedAt: z.string().datetime().optional(),
 	reminderPlatform: reminderPlatformSchema,

--- a/src/create-reminder-signup/lib/identity.ts
+++ b/src/create-reminder-signup/lib/identity.ts
@@ -36,13 +36,13 @@ const createIdentityAccount = async (
 		IDENTITY_ACCOUNT_CREATION_MAX_RETRIES,
 	);
 	if (!response.ok) {
-		return response.text().then((body) => {
+		return response.json().then((body) => {
 			console.log(
 				'Identity guest account creation failed',
 				response.status,
 				body,
 			);
-			return fail(response.status);
+			return fail(response.status, body);
 		});
 	}
 

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -19,14 +19,12 @@ export interface IdentitySuccess {
 	identityId: string;
 }
 
-//TODO: move to models?
 export interface IdentityErrorMessage {
 	message: string;
 	description: string;
 	context?: string;
 }
 
-//TODO: move to models?
 export interface IdentityError {
 	status: 'error';
 	errors: IdentityErrorMessage[];

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -19,9 +19,23 @@ export interface IdentitySuccess {
 	identityId: string;
 }
 
+//TODO: move to models?
+export interface IdentityErrorMessage {
+	message: string;
+	description: string;
+	context?: string;
+}
+
+//TODO: move to models?
+export interface IdentityError {
+	status: 'error';
+	errors: IdentityErrorMessage[];
+}
+
 export interface IdentityFailure {
 	name: 'failure';
 	status: number;
+	errorMessage?: IdentityError;
 }
 export type IdentityResult = IdentitySuccess | IdentityFailure;
 
@@ -30,9 +44,13 @@ export const success = (identityId: string): IdentitySuccess => ({
 	identityId,
 });
 
-export const fail = (status: number): IdentityFailure => ({
+export const fail = (
+	status: number,
+	message?: IdentityError,
+): IdentityFailure => ({
 	name: 'failure',
 	status,
+	errorMessage: message,
 });
 
 export const getIdentityIdByEmail = async (
@@ -47,13 +65,13 @@ export const getIdentityIdByEmail = async (
 	);
 
 	if (!response.ok) {
-		return response.text().then((body) => {
+		return response.json().then((body: IdentityError) => {
 			console.log(
 				`Unable to lookup identity ID for email ${email}`,
 				response.status,
 				body,
 			);
-			return fail(response.status);
+			return fail(response.status, body);
 		});
 	}
 


### PR DESCRIPTION
## What does this change?

It was discovered that there were many items on the support-reminders dead letter queue which is causing the support-reminders alert to be permanently in an alarm state.  Unfortunately, these are not able to be fixed owing to:
 
1. Invalid email addresses
2. Email providers which are blocked

We are not able to fix these reminder tasks so the best we can do is to check and then remove them, which adds an overhead of checking each item on the DLQ.

This change picks up the error message returned from IDAPI to check for those two types of validation failures and ensures they are not dropped into the DLQ.

This, in conjunction with [DCR PR14110](https://github.com/guardian/dotcom-rendering/pull/14110) which adds basic HTML email validation, should reduce the number of items that end up on the DQL to tasks we may be able to do something with. 

The Zod email validation we are currently use picks up a different subset of email validation errors compared to Okta.  Removing this ensures that only the Okta validation will reject errors since Identity use the Okta validation before creating an Identity record. 

[Trello ticket](https://trello.com/c/TUGktATw)

## How to test

Deploy to CODE, POST support-reminder tasks with valid and invalid addresses and check if they end up on the DLQ or are added to the db. 

[Okta validation doc](https://help.okta.com/en-us/content/topics/directory/reference_directories.htm)

## How can we measure success?

A reduction in the amount of invalid emails on the DLQ and time spend fixing.  The invalid items already on the DLQ, when we run a redrive, should disappear and the alert should revert to an OK state.

## Have we considered potential risks?

There is a slight concern about injection attacks making it through to the IDAPI endpoint however, Identity validate the email addresses before insertion.

