### PR TITLE
Do not create account if user is in an incomplete state - return error to calling function instead to be ignored

### DIFF
--- a/src/create-reminder-signup/lib/identity.ts
+++ b/src/create-reminder-signup/lib/identity.ts
@@ -71,7 +71,11 @@ export const getOrCreateIdentityIdByEmail = async (
 	if (
 		result.name === 'failure' &&
 		result.status === 404 &&
-		reminderStage === 'PRE'
+		reminderStage === 'PRE' &&
+		// don't try to create an account if they're already in an incomplete state
+		!result.errorMessage?.errors.some(
+			(m) => m.message === 'Incomplete user',
+		)
 	) {
 		return createIdentityAccount(email, accessToken);
 	}


### PR DESCRIPTION
## What does this change?

Addition to [PR298](https://github.com/guardian/support-reminders/pull/298) because the error was not being returned to the calling function in order to check if it needed to be ignored.  

By adding this line, we only try to create the account if the error message is NOT 'Incomplete user' otherwise the error is be returned to the calling function so it can be processed in the ignoreSomeValidationErrors function.

## How to test

Deploy to CODE, POST support-reminder tasks with an email address that exists in Okta but has not been verified and check if the event ends up on the DLQ or is added to the db.

## How can we measure success?

On rerunning the DLQ in PROD - and **waiting 5 minutes**, the existing events with this issue will disappear and there will be no future recurrences, resolving the alarm that has been recurrently alerting.