### PR TITLE
Remove ACL from S3 upload to meet FSBP security requirement s3-6

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -1191,10 +1191,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-              ],
+              "Action": "s3:PutObject",
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:s3:::contributions-private",
@@ -4326,10 +4323,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-              ],
+              "Action": "s3:PutObject",
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:s3:::ophan-raw-support-reminders",

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -354,8 +354,7 @@ export class SupportReminders extends GuStack {
 				new PolicyStatement({
 					effect: Effect.ALLOW,
 					actions: [
-						"s3:PutObject",
-						"s3:PutObjectAcl"
+						"s3:PutObject"
 					],
 					resources: [
 						`arn:aws:s3:::${props.datalakeBucket}`,

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -27,7 +27,6 @@ export function uploadAsCsvToS3(
 			Bucket: bucket,
 			Key: key,
 			Body: csv,
-			ACL: 'bucket-owner-full-control',
 		})
 		.promise()
 		.then(() => result.rowCount ?? 0);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This change removes the ACL from the s3.upload command in [upload.ts](https://github.com/guardian/support-reminders/blob/main/src/lib/upload.ts).
It also removes the s3:PutObjectAcl permission from the (s3PutObjectInlinePolicy)[https://github.com/guardian/support-reminders/blob/398f8b1890760c6d68cf0e9ab9780bf30d497682/cdk/lib/support-reminders.ts#L352] cdk definition.

The reason for these changes is that the destination bucket: [ophan-raw-support-reminders](https://eu-west-1.console.aws.amazon.com/s3/buckets/ophan-raw-support-reminders?region=eu-west-1&bucketType=general&tab=permissions) is currently in breach of FSBP Security requirement [S-3.6: S3 general purpose bucket policies should restrict access to other AWS accounts](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-6 ). To bring this bucket in-line with the requirement, we must restrict the permissions for the aws account that is writing the object to the minimum, removing any ability to write ACL for the objects.

This should have minimal impact as the only ACL being written was one specifying full bucket ownership. The change follows a similar approach to that used successfully in [this PR](https://github.com/guardian/eventbrite-baton-requests/pull/41) to fix a different bucket for the same FSBP requirement.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
