### PR TITLE
Revert "Remove ACL from S3 upload to meet FSBP security requirement s3-6"

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -1191,7 +1191,10 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "s3:PutObject",
+              "Action": [
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+              ],
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:s3:::contributions-private",
@@ -4323,7 +4326,10 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "s3:PutObject",
+              "Action": [
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+              ],
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:s3:::ophan-raw-support-reminders",

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -354,7 +354,8 @@ export class SupportReminders extends GuStack {
 				new PolicyStatement({
 					effect: Effect.ALLOW,
 					actions: [
-						"s3:PutObject"
+						"s3:PutObject",
+						"s3:PutObjectAcl"
 					],
 					resources: [
 						`arn:aws:s3:::${props.datalakeBucket}`,

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -27,6 +27,7 @@ export function uploadAsCsvToS3(
 			Bucket: bucket,
 			Key: key,
 			Body: csv,
+			ACL: 'bucket-owner-full-control',
 		})
 		.promise()
 		.then(() => result.rowCount ?? 0);


### PR DESCRIPTION
Reverts guardian/support-reminders#302

After merging this, we are experiencing some issues so undoing all the steps until we can isolate the triger.