### PR TITLE
Log request body and user agent

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -418,7 +418,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
               "Arn",
             ],
           },
-          "Format": "{"requestId":"$context.requestId","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","requestBody":"$util.escapeJavaScript($input.body)","userAgent":"$context.identity.userAgent"}",
+          "Format": "{"requestId":"$context.requestId","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","rawBody":"$input.path('$')","userAgent":"$context.identity.userAgent"}",
         },
         "DeploymentId": {
           "Ref": "RestApiDeployment180EC503a345def70b385514941e7a699c9d376f",
@@ -3553,7 +3553,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
               "Arn",
             ],
           },
-          "Format": "{"requestId":"$context.requestId","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","requestBody":"$util.escapeJavaScript($input.body)","userAgent":"$context.identity.userAgent"}",
+          "Format": "{"requestId":"$context.requestId","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","rawBody":"$input.path('$')","userAgent":"$context.identity.userAgent"}",
         },
         "DeploymentId": {
           "Ref": "RestApiDeployment180EC503527c2dadd44b8927ecf4437252adb507",

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -197,7 +197,7 @@ export class SupportReminders extends GuStack {
 						status: '$context.status',
 						protocol: '$context.protocol',
 						responseLength: '$context.responseLength',
-						requestBody: '$util.escapeJavaScript($input.body)',
+						rawBody: '$input.path(\'$\')',
 						userAgent: '$context.identity.userAgent'
 					})
 				),


### PR DESCRIPTION
We sometimes get requests to the /create/one-off endpoint which are passed to the queue for processing, but then fail because the body is empty. This PR attempts to improve the API logs to see if we can learn more about these requests.