### PR TITLE
Reapply: Remove ACL from S3 upload to meet FSBP security requirement s3-6

### DIFF
--- a/cdk/lib/__snapshots__/support-reminders.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-reminders.test.ts.snap
@@ -1225,10 +1225,7 @@ exports[`The SupportReminders stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-              ],
+              "Action": "s3:PutObject",
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:s3:::contributions-private",
@@ -4396,10 +4393,7 @@ exports[`The SupportReminders stack matches the snapshot 2`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-              ],
+              "Action": "s3:PutObject",
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:s3:::ophan-raw-support-reminders",

--- a/cdk/lib/support-reminders.ts
+++ b/cdk/lib/support-reminders.ts
@@ -389,8 +389,7 @@ export class SupportReminders extends GuStack {
 				new PolicyStatement({
 					effect: Effect.ALLOW,
 					actions: [
-						"s3:PutObject",
-						"s3:PutObjectAcl"
+						"s3:PutObject"
 					],
 					resources: [
 						`arn:aws:s3:::${props.datalakeBucket}`,

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -26,7 +26,6 @@ export function uploadAsCsvToS3(
 		Bucket: bucket,
 		Key: key,
 		Body: csv,
-		ACL: 'bucket-owner-full-control',
 	});
 
 	return s3.send(command).then(() => result.rowCount ?? 0);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This reapplies #302. This change was reverted as the S3 bucket was still expecting an ACL to be uploaded with the data objects. When this ACL was not uploaded, the data was not accessible by anyone.

This new application will be merged in concert with ophan-data-lake pr [#8511](https://github.com/guardian/ophan-data-lake/pull/8511) - this change removes the expectation for a ACL to be provided with the data object and sets the object ownership for that object to the account that owns the bucket. This means that airflow will still be able to access the written objects.

## Details of the change: 
This change removes the ACL from the s3.upload command in [upload.ts](https://github.com/guardian/support-reminders/blob/main/src/lib/upload.ts).
It also removes the s3:PutObjectAcl permission from the (s3PutObjectInlinePolicy)[https://github.com/guardian/support-reminders/blob/398f8b1890760c6d68cf0e9ab9780bf30d497682/cdk/lib/support-reminders.ts#L352] cdk definition.

The reason for these changes is that the destination bucket: [ophan-raw-support-reminders](https://eu-west-1.console.aws.amazon.com/s3/buckets/ophan-raw-support-reminders?region=eu-west-1&bucketType=general&tab=permissions) is currently in breach of FSBP Security requirement [S-3.6: S3 general purpose bucket policies should restrict access to other AWS accounts](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-6). To bring this bucket in-line with the requirement, we must restrict the permissions for the aws account that is writing the object to the minimum, removing any ability to write ACL for the objects.

This should have minimal impact as the only ACL being written was one specifying full bucket ownership. The change follows a similar approach to that used successfully in https://github.com/guardian/eventbrite-baton-requests/pull/41 to fix a different bucket for the same FSBP requirement.

How to test
Deploy branch to PROD during suitable time
Confirm configuration changes are present in both lambda cloudformation and in destination s3 bucket
Note what files are currently in destination s3 bucket especially creation/last modified time
Run lambda using test functionality
Confirm no errors raised and create/modify time(s) now match the time the lambda run (thus confirming the s3 files were transferred).
Cleanup: Redeploy current main branch, confirm Cloudformation for lambda is returned to normal.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
