### PR TITLE
Update dependabot configuration to fit new pnpm workspace setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,19 +11,12 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 7
-
-  - package-ecosystem: 'npm'
-    directory: '/cdk'
     # The version of aws-cdk-lib libraries must match those from @guardian/cdk.
     # We'd never be able to update them here independently, so just ignore them.
     ignore:
       - dependency-name: 'aws-cdk'
       - dependency-name: 'aws-cdk-lib'
       - dependency-name: '@aws-cdk/*'
-    schedule:
-      interval: 'weekly'
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## What does this change?

On noticing new dependabot PRs for aws-cdk and aws-cdk-lib which were ignored under the /cdk directory in dependabot .yml file, it became clear that moving from yarn to pnpm v10 with a workspace requires some changes to the dependabot configuration to account for that.

Dependabot uses the pnpm.lock file which now only exists at the root of the repo and, as there is no lock file at the /cdk level, basically ignores anything listed under /cdk section of the configuration file.  This moves the ignores section to the root of the dependabot configuration.

## How has this change been tested?

This can't exactly be tested but it can be reverted if necessary.
I will keep my eye on the dependabot PRs as they're recreated to see if this closes the aws-cdk, aws-cdk-lib PRs and, if not close them.